### PR TITLE
Add tests for components and utility

### DIFF
--- a/src/components/EnemyCard.test.tsx
+++ b/src/components/EnemyCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import EnemyCard from './EnemyCard';
+import type { Enemy, UserProfile } from '../types';
+
+describe('EnemyCard', () => {
+  const enemy: Enemy = {
+    id: '1',
+    name: 'Orc',
+    customDescription: 'desc',
+    tags: ['tag1', 'tag2'],
+    customTags: [],
+    imageURL: 'img.jpg',
+    authorUid: 'user1'
+  };
+  const author: UserProfile = {
+    displayName: 'Author',
+    photoURL: 'avatar.jpg'
+  };
+
+  it('renders enemy name and tags and handles click', () => {
+    const onClick = jest.fn();
+    render(<EnemyCard index={0} enemy={enemy} author={author} onClick={onClick} />);
+
+    expect(screen.getByText('Orc')).toBeInTheDocument();
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('tag2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Orc'));
+    expect(onClick).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/components/EnemyList.test.tsx
+++ b/src/components/EnemyList.test.tsx
@@ -7,7 +7,9 @@ jest.mock('../contexts/AuthContext', () => ({
 }));
 
 jest.mock('./AddEnemy', () => () => <div data-testid="add-enemy" />);
-jest.mock('./EnemyCard', () => ({ index, enemy, onClick }: any) => (
+import type { Enemy } from '../types';
+
+jest.mock('./EnemyCard', () => ({ index, enemy, onClick }: { index: number; enemy: Enemy; onClick: (idx: number) => void }) => (
   <div data-testid={`card-${index}`} onClick={() => onClick(index)}>{enemy.name}</div>
 ));
 

--- a/src/components/EnemyList.test.tsx
+++ b/src/components/EnemyList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import EnemyList from './EnemyList';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn()
+}));
+
+jest.mock('./AddEnemy', () => () => <div data-testid="add-enemy" />);
+jest.mock('./EnemyCard', () => ({ index, enemy, onClick }: any) => (
+  <div data-testid={`card-${index}`} onClick={() => onClick(index)}>{enemy.name}</div>
+));
+
+describe('EnemyList', () => {
+  it('shows AddEnemy when user logged in', () => {
+    (useAuth as jest.Mock).mockReturnValue({ uid: '1' });
+    render(<EnemyList enemies={[]} users={{}} onSelect={jest.fn()} />);
+    expect(screen.getByTestId('add-enemy')).toBeInTheDocument();
+  });
+
+  it('hides AddEnemy when user not logged in', () => {
+    (useAuth as jest.Mock).mockReturnValue(null);
+    render(<EnemyList enemies={[]} users={{}} onSelect={jest.fn()} />);
+    expect(screen.queryByTestId('add-enemy')).toBeNull();
+  });
+
+  it('renders enemy cards and handles selection', () => {
+    (useAuth as jest.Mock).mockReturnValue(null);
+    const enemies = [{
+      id: '1',
+      name: 'E1',
+      customDescription: '',
+      tags: [],
+      customTags: [],
+      imageURL: 'img',
+      authorUid: 'u1'
+    }];
+    const onSelect = jest.fn();
+    render(<EnemyList enemies={enemies} users={{}} onSelect={onSelect} />);
+    const card = screen.getByTestId('card-0');
+    expect(card).toHaveTextContent('E1');
+    fireEvent.click(card);
+    expect(onSelect).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/utils/fetchUserProfiles.test.ts
+++ b/src/utils/fetchUserProfiles.test.ts
@@ -1,0 +1,31 @@
+import { fetchUserProfiles } from './fetchUserProfiles';
+import { getDoc, doc } from 'firebase/firestore';
+
+jest.mock('../firebase', () => ({ db: {} }));
+
+jest.mock('firebase/firestore', () => ({
+  getDoc: jest.fn(),
+  doc: jest.fn(() => 'doc-ref')
+}));
+
+describe('fetchUserProfiles', () => {
+  it('fetches profiles for each uid', async () => {
+    (getDoc as jest.Mock).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ displayName: 'User1', photoURL: 'url1' })
+    });
+    (getDoc as jest.Mock).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ displayName: 'User2', photoURL: 'url2' })
+    });
+
+    const profiles = await fetchUserProfiles(['uid1', 'uid2']);
+
+    expect(doc).toHaveBeenCalledWith(expect.anything(), 'users', 'uid1');
+    expect(doc).toHaveBeenCalledWith(expect.anything(), 'users', 'uid2');
+    expect(profiles).toEqual({
+      uid1: { displayName: 'User1', photoURL: 'url1' },
+      uid2: { displayName: 'User2', photoURL: 'url2' }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `EnemyCard` component
- add unit tests for `EnemyList` component
- add tests for `fetchUserProfiles` utility

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6841585b07648324a797e7c21a01c431