### PR TITLE
Add keyboard shortcuts for enemy navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,21 @@ const App: React.FC = () => {
 
   const selectedEnemy = selectedIndex !== null ? enemies[selectedIndex] : null;
 
+  useEffect(() => {
+    if (selectedEnemy === null) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        handlePrev();
+      } else if (e.key === 'ArrowRight') {
+        handleNext();
+      } else if (e.key === 'Escape') {
+        setSelectedIndex(null);
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [selectedEnemy, handlePrev, handleNext]);
+
   return (
     <div className="bg-slate-900 text-sky-200 min-h-screen">
       <Header />

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -46,10 +46,19 @@ const AddEnemy: React.FC = () => {
         setIsOpen(false);
       }
     };
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
     if (isOpen) {
       document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleEsc);
     }
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEsc);
+    };
   }, [isOpen]);
 
   if (!isOpen) {

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import ReactMarkdown from "react-markdown";
 import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
@@ -17,6 +17,25 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     const user = useAuth();
     const cardRef = useRef<HTMLDivElement | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+
+    useEffect(() => {
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                if (isEditing) {
+                    setIsEditing(false);
+                } else {
+                    close();
+                }
+            } else if (!isEditing && e.key === 'ArrowLeft') {
+                onPrev();
+            } else if (!isEditing && e.key === 'ArrowRight') {
+                onNext();
+            }
+        };
+
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, [isEditing, close, onPrev, onNext]);
 
     // Close card when clicking outside
     const handleClickOutside = (event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- switch cards with arrow keys and close with Escape
- close AddEnemy modal with Escape

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841658953c083248fa6bb03281392d1