### PR TITLE
Implement "like" star for enemies

### DIFF
--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -29,6 +29,7 @@ const AddEnemy: React.FC = () => {
       imageURL,
       imageURL2,
       authorUid: user.uid,
+      likedBy: [],
     };
     await addDoc(enemiesCollection, newEnemy);
     setIsOpen(false);

--- a/src/components/EnemyCard.test.tsx
+++ b/src/components/EnemyCard.test.tsx
@@ -1,6 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import EnemyCard from './EnemyCard';
 import type { Enemy, UserProfile } from '../types';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn()
+}));
+
+jest.mock('../firebase', () => ({ db: {} }));
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  updateDoc: jest.fn(),
+  arrayUnion: jest.fn((v) => v),
+  arrayRemove: jest.fn((v) => v)
+}));
 
 describe('EnemyCard', () => {
   const enemy: Enemy = {
@@ -10,7 +24,8 @@ describe('EnemyCard', () => {
     tags: ['tag1', 'tag2'],
     customTags: [],
     imageURL: 'img.jpg',
-    authorUid: 'user1'
+    authorUid: 'user1',
+    likedBy: []
   };
   const author: UserProfile = {
     displayName: 'Author',
@@ -19,11 +34,17 @@ describe('EnemyCard', () => {
 
   it('renders enemy name and tags and handles click', () => {
     const onClick = jest.fn();
+    (useAuth as jest.Mock).mockReturnValue({ uid: 'user1' });
     render(<EnemyCard index={0} enemy={enemy} author={author} onClick={onClick} />);
 
     expect(screen.getByText('Orc')).toBeInTheDocument();
     expect(screen.getByText('tag1')).toBeInTheDocument();
     expect(screen.getByText('tag2')).toBeInTheDocument();
+
+    expect(screen.getByTitle('Сохранить')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Сохранить'));
+    expect(onClick).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText('Orc'));
     expect(onClick).toHaveBeenCalledWith(0);

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -40,7 +40,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
         <button
             onClick={toggleLike}
             title={liked ? 'Сохранено' : 'Сохранить'}
-            className="absolute top-2 right-2 text-yellow-400 hover:scale-110 transition"
+            className="absolute top-2 right-2 text-blue-300 hover:scale-110 transition"
         >
             {liked ? <StarSolid className="w-5 h-5" /> : <StarOutline className="w-5 h-5" />}
         </button>

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -1,4 +1,9 @@
 import { useRef } from "react";
+import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
+import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
+import { StarIcon as StarOutline } from "@heroicons/react/24/outline";
+import { db } from "../firebase";
+import { useAuth } from "../contexts/AuthContext";
 import type { Enemy, UserProfile } from "../types";
 
 interface Props {
@@ -9,6 +14,18 @@ interface Props {
 }
 const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     const cardRef = useRef<HTMLDivElement | null>(null);
+    const user = useAuth();
+
+    const liked = !!user && enemy.likedBy?.includes(user.uid);
+
+    const toggleLike = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!user || !enemy.id) return;
+        const ref = doc(db, "eotv-enemies", enemy.id);
+        await updateDoc(ref, {
+            likedBy: liked ? arrayRemove(user.uid) : arrayUnion(user.uid)
+        });
+    };
 
     return (
     <div
@@ -19,6 +36,14 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     >
         {/* 1st image */}
         <img src={enemy.imageURL} alt={enemy.name} className="w-full h-32 object-cover" />
+
+        <button
+            onClick={toggleLike}
+            title={liked ? 'Сохранено' : 'Сохранить'}
+            className="absolute top-2 right-2 text-yellow-400 hover:scale-110 transition"
+        >
+            {liked ? <StarSolid className="w-5 h-5" /> : <StarOutline className="w-5 h-5" />}
+        </button>
 
         <div className="p-2 flex flex-col">
             {/* Name */}

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -1,7 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import ReactMarkdown from "react-markdown";
-import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon, StarIcon as StarOutline } from "@heroicons/react/24/outline";
+import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
+import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
+import { db } from "../firebase";
 import EditEnemy from "./EditEnemy";
 import type { Enemy, UserProfile } from "../types";
 
@@ -17,6 +20,15 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     const user = useAuth();
     const cardRef = useRef<HTMLDivElement | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    const liked = !!user && enemy.likedBy?.includes(user.uid);
+
+    const toggleLike = async () => {
+        if (!user || !enemy.id) return;
+        const ref = doc(db, "eotv-enemies", enemy.id);
+        await updateDoc(ref, {
+            likedBy: liked ? arrayRemove(user.uid) : arrayUnion(user.uid)
+        });
+    };
 
     useEffect(() => {
         const handleKey = (e: KeyboardEvent) => {
@@ -93,22 +105,31 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                         <img src={author?.photoURL} alt="Avatar" className="w-8 h-8 rounded-full border border-gray-500" />
                     </div>
 
+                    {/* Action buttons */}
+                    <div className="absolute top-2 right-10 flex gap-2">
+                        <button
+                            onClick={toggleLike}
+                            title={liked ? 'Сохранено' : 'Сохранить'}
+                            className="text-yellow-400 hover:scale-110 transition"
+                        >
+                            {liked ? <StarSolid className="w-6 h-6" /> : <StarOutline className="w-6 h-6" />}
+                        </button>
+                        {user && user.uid === enemy.authorUid && (
+                            <>
+                                <button onClick={() => setIsEditing(true)} className="text-gray-300 hover:text-white cursor-pointer drop-shadow-md">
+                                    <PencilSquareIcon className="w-6 h-6" />
+                                </button>
+                                <button onClick={onDelete} className="text-gray-300 hover:text-white cursor-pointer drop-shadow-md">
+                                    <TrashIcon className="w-6 h-6" />
+                                </button>
+                            </>
+                        )}
+                    </div>
+
                     {/* Close button */}
                     <button onClick={close} className="absolute top-2 right-2 text-gray-300 hover:text-white cursor-pointer drop-shadow-xl">
                         <XMarkIcon className="w-6 h-6" />
                     </button>
-
-                    {/* Edit and Delete buttons */}
-                    {user && user.uid === enemy.authorUid && (
-                        <div className="absolute top-2 right-10 flex gap-2">
-                            <button onClick={() => setIsEditing(true)} className="text-gray-300 hover:text-white cursor-pointer drop-shadow-md">
-                                <PencilSquareIcon className="w-6 h-6" />
-                            </button>
-                            <button onClick={onDelete} className="text-gray-300 hover:text-white cursor-pointer drop-shadow-md">
-                                <TrashIcon className="w-6 h-6" />
-                            </button>
-                        </div>
-                    )}
 
                     {/* Navigation between cards */}
                     <button className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onPrev}>

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -110,7 +110,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                         <button
                             onClick={toggleLike}
                             title={liked ? 'Сохранено' : 'Сохранить'}
-                            className="text-yellow-400 hover:scale-110 transition"
+                            className="text-gray-300 hover:scale-110 transition"
                         >
                             {liked ? <StarSolid className="w-6 h-6" /> : <StarOutline className="w-6 h-6" />}
                         </button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Enemy {
   imageURL: string;
   imageURL2?: string;
   authorUid: string;
+  likedBy?: string[];
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- add `likedBy` field to `Enemy` type and add initial value when creating new enemies
- implement like toggling in `EnemyCard` and `EnemyDetail` with star icons
- adjust card tests for new button

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841693ede2c8324ac8f3bf2350ba843