### PR TITLE
Implement fixed tag filtering

### DIFF
--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import type { Enemy, UserProfile } from "../types";
+import useFixedTags from "../utils/useFixedTags";
 
 interface Props {
   index: number;
@@ -9,6 +10,8 @@ interface Props {
 }
 const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     const cardRef = useRef<HTMLDivElement | null>(null);
+    const fixedTags = useFixedTags();
+    const displayedTags = fixedTags.length ? enemy.tags.filter(t => fixedTags.includes(t)) : enemy.tags;
 
     return (
     <div
@@ -27,7 +30,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
             {/* Tags */}
             <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">
                 <div className="flex flex-wrap gap-1">
-                {enemy.tags.map((tag, index) => (
+                {displayedTags.map((tag, index) => (
                     <span key={index} className="bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
                 ))}
                 </div>

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import EditEnemy from "./EditEnemy";
 import type { Enemy, UserProfile } from "../types";
+import useFixedTags from "../utils/useFixedTags";
 
 interface Props {
   enemy: Enemy;
@@ -17,6 +18,8 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     const user = useAuth();
     const cardRef = useRef<HTMLDivElement | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    const fixedTags = useFixedTags();
+    const displayedTags = fixedTags.length ? enemy.tags.filter(t => fixedTags.includes(t)) : enemy.tags;
 
     useEffect(() => {
         const handleKey = (e: KeyboardEvent) => {
@@ -81,7 +84,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     {/* Tags */}
                     <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">
                         <div className="flex flex-wrap gap-1">
-                        {enemy.tags.map((tag, index) => (
+                        {displayedTags.map((tag, index) => (
                             <span key={index} className="bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
                         ))}
                         </div>

--- a/src/components/TagBox.tsx
+++ b/src/components/TagBox.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState, useCallback } from "react";
-import { getDocs } from "firebase/firestore";
-import { tagsCollection } from "../firebase";
+import { useState, useCallback } from "react";
+import useFixedTags from "../utils/useFixedTags";
 
 interface Props {
   selectedTags: string[];
@@ -9,21 +8,12 @@ interface Props {
   setCustomTags: (tags: string[]) => void;
 }
 
-interface TagDoc { id: string; slug: string; name: string }
-
 const TagBox: React.FC<Props> = ({ selectedTags, setSelectedTags, customTags, setCustomTags }) => {
-  const [availableTags, setAvailableTags] = useState<TagDoc[]>([]);
+  const availableTags = useFixedTags();
   const [input, setInput] = useState("");
 
-  useEffect(() => {
-    const fetchTags = async () => {
-      const qs = await getDocs(tagsCollection);
-      setAvailableTags(qs.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<TagDoc, "id">) })));
-    };
-    fetchTags();
-  }, []);
-
-  const allSuggestions = Array.from(new Set([...availableTags.map(t => t.slug), ...customTags]));
+  const allSuggestions = Array.from(new Set([...availableTags, ...customTags]));
+  const filteredSuggestions = allSuggestions.filter(tag => tag.toLowerCase().includes(input.toLowerCase()));
 
   const addTag = useCallback((tag: string) => {
     const trimmed = tag.trim();
@@ -31,7 +21,7 @@ const TagBox: React.FC<Props> = ({ selectedTags, setSelectedTags, customTags, se
     if (!selectedTags.includes(trimmed)) {
       setSelectedTags([...selectedTags, trimmed]);
     }
-    if (!availableTags.some(t => t.slug === trimmed) && !customTags.includes(trimmed)) {
+    if (!availableTags.includes(trimmed) && !customTags.includes(trimmed)) {
       setCustomTags([...customTags, trimmed]);
     }
   }, [selectedTags, setSelectedTags, availableTags, customTags, setCustomTags]);
@@ -67,7 +57,7 @@ const TagBox: React.FC<Props> = ({ selectedTags, setSelectedTags, customTags, se
           className="bg-transparent outline-none flex-1 text-sm text-white"
         />
         <datalist id="tag-suggestions">
-          {allSuggestions.map(tag => (
+          {filteredSuggestions.map(tag => (
             <option key={tag} value={tag} />
           ))}
         </datalist>

--- a/src/utils/useFixedTags.ts
+++ b/src/utils/useFixedTags.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+import { getDocs } from "firebase/firestore";
+import { tagsCollection } from "../firebase";
+
+const useFixedTags = () => {
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      const qs = await getDocs(tagsCollection);
+      setTags(qs.docs.map(doc => (doc.data().name as string)));
+    };
+    fetchTags();
+  }, []);
+
+  return tags;
+};
+
+export default useFixedTags;


### PR DESCRIPTION
## Summary
- provide a `useFixedTags` hook for reading enemy tags from Firestore
- filter tags displayed in `EnemyCard` and `EnemyDetail` using fixed tags
- update `TagBox` to use the new hook and filter suggestions by substring

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68417b74f13c832497bbf9964f7b4d4f