### PR TITLE
Add enemy search and filter panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { enemiesCollection, db } from "./firebase";
 import EnemyList from "./components/EnemyList";
 import EnemyDetail from "./components/EnemyDetail";
 import Header from "./components/Header";
+import EnemyFilters from "./components/EnemyFilters";
 import type { Enemy, UserProfile } from "./types";
 import { useAuth } from "./contexts/AuthContext";
 import { fetchUserProfiles } from "./utils/fetchUserProfiles";
@@ -12,6 +13,11 @@ const App: React.FC = () => {
   const [enemies, setEnemies] = useState<Enemy[]>([]);
   const [profiles, setProfiles] = useState<Record<string, UserProfile>>({});
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [search, setSearch] = useState("");
+  const [tag, setTag] = useState("");
+  const [liked, setLiked] = useState(false);
+  const [author, setAuthor] = useState("");
+  const [sort, setSort] = useState("name");
   const user = useAuth();
 
   useEffect(() => {
@@ -47,6 +53,33 @@ const App: React.FC = () => {
 
   const selectedEnemy = selectedIndex !== null ? enemies[selectedIndex] : null;
 
+  const normalizedSearch = search.toLowerCase();
+  let filtered = enemies.filter(e =>
+    e.name.toLowerCase().includes(normalizedSearch) ||
+    e.customDescription.toLowerCase().includes(normalizedSearch) ||
+    e.tags.some(t => t.toLowerCase().includes(normalizedSearch)) ||
+    e.customTags.some(t => t.toLowerCase().includes(normalizedSearch))
+  );
+  if (tag) {
+    filtered = filtered.filter(e => e.tags.includes(tag));
+  }
+  if (liked && user) {
+    filtered = filtered.filter(e => e.likedBy?.includes(user.uid));
+  }
+  if (author) {
+    filtered = filtered.filter(e => e.authorUid === author);
+  }
+  filtered = [...filtered];
+  if (sort === "name") {
+    filtered.sort((a, b) => a.name.localeCompare(b.name));
+  } else {
+    filtered.sort((a, b) => {
+      const ad = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bd = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bd - ad;
+    });
+  }
+
   useEffect(() => {
     if (selectedEnemy === null) return;
     const handleKey = (e: KeyboardEvent) => {
@@ -68,7 +101,20 @@ const App: React.FC = () => {
       <main className="p-6 max-w-screen-xl mx-auto">
         <h2 className="text-3xl font-bold text-center">Каталог противников для игры Грань Вселенной</h2>
         <p className="text-center text-gray-400 p-4">Официальный сайт игры: <a className="link" href="http://eotvrpg.ru/" target="_blank">http://eotvrpg.ru/</a></p>
-        <EnemyList enemies={enemies} users={profiles} onSelect={setSelectedIndex} />
+        <EnemyFilters
+          search={search}
+          setSearch={setSearch}
+          tag={tag}
+          setTag={setTag}
+          liked={liked}
+          setLiked={setLiked}
+          author={author}
+          setAuthor={setAuthor}
+          sort={sort}
+          setSort={setSort}
+          authors={profiles}
+        />
+        <EnemyList enemies={filtered} users={profiles} onSelect={setSelectedIndex} />
       </main>
       {selectedEnemy && (
         <EnemyDetail

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -30,6 +30,7 @@ const AddEnemy: React.FC = () => {
       imageURL2,
       authorUid: user.uid,
       likedBy: [],
+      createdAt: new Date().toISOString(),
     };
     await addDoc(enemiesCollection, newEnemy);
     setIsOpen(false);

--- a/src/components/EditEnemy.tsx
+++ b/src/components/EditEnemy.tsx
@@ -30,6 +30,9 @@ const EditEnemy: React.FC<Props> = ({ enemy, onClose }) => {
       imageURL,
       imageURL2,
     };
+    if (!enemy.createdAt) {
+      updatedEnemy.createdAt = new Date().toISOString();
+    }
     await updateDoc(enemyDocRef, updatedEnemy);
   }, [enemy.id, name, customDescription, selectedTags, customTags, imageURL, imageURL2]);
 

--- a/src/components/EnemyFilters.tsx
+++ b/src/components/EnemyFilters.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import type { UserProfile } from "../types";
+import { useFixedTags } from "../contexts/TagContext";
+
+interface Props {
+  search: string;
+  setSearch: (v: string) => void;
+  tag: string;
+  setTag: (v: string) => void;
+  liked: boolean;
+  setLiked: (v: boolean) => void;
+  author: string;
+  setAuthor: (v: string) => void;
+  sort: string;
+  setSort: (v: string) => void;
+  authors: Record<string, UserProfile>;
+}
+
+const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, setLiked, author, setAuthor, sort, setSort, authors }) => {
+  const fixedTags = useFixedTags();
+  const [authorOpen, setAuthorOpen] = useState(false);
+  const authorProfile = author ? authors[author] : undefined;
+
+  return (
+    <div className="flex flex-wrap gap-4 my-4 items-end">
+      <input
+        type="text"
+        placeholder="Поиск"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        className="p-2 rounded bg-gray-700 text-white flex-1"
+      />
+      <div>
+        <label className="block text-sm mb-1">Тег</label>
+        <select value={tag} onChange={e => setTag(e.target.value)} className="p-2 rounded bg-gray-700 text-white">
+          <option value="">Все</option>
+          {fixedTags.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={liked} onChange={e => setLiked(e.target.checked)} />
+        Избранное
+      </label>
+      <div className="relative">
+        <button type="button" onClick={() => setAuthorOpen(o => !o)} className="p-2 rounded bg-gray-700 text-white flex items-center gap-2">
+          {authorProfile && <img src={authorProfile.photoURL} alt="avatar" className="w-6 h-6 rounded-full" />}
+          <span>{authorProfile ? authorProfile.displayName : 'Автор'}</span>
+        </button>
+        {authorOpen && (
+          <div className="absolute z-10 bg-gray-800 rounded shadow p-2 mt-1 max-h-60 overflow-y-auto">
+            <div className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2" onClick={() => { setAuthor(''); setAuthorOpen(false); }}>
+              <span>Все авторы</span>
+            </div>
+            {Object.entries(authors).map(([uid, prof]) => (
+              <div key={uid} className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2" onClick={() => { setAuthor(uid); setAuthorOpen(false); }}>
+                <img src={prof.photoURL} alt={prof.displayName} className="w-6 h-6 rounded-full" />
+                <span>{prof.displayName}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Сортировать</label>
+        <select value={sort} onChange={e => setSort(e.target.value)} className="p-2 rounded bg-gray-700 text-white">
+          <option value="name">По имени</option>
+          <option value="date">По дате</option>
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default EnemyFilters;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Enemy {
   imageURL2?: string;
   authorUid: string;
   likedBy?: string[];
+  createdAt?: string;
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- add EnemyFilters component with search, tag, liked, author and sort controls
- save createdAt when creating enemies
- backfill missing createdAt when editing enemies
- filter and sort enemies in App

## Testing
- `npm test --silent`
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684184bc80188324b4c9a329c8dc9864