### PR TITLE
Add login prompts for unauthorized actions

### DIFF
--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { addDoc } from "firebase/firestore";
-import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
-import { auth, enemiesCollection } from "../firebase";
+import { enemiesCollection } from "../firebase";
 import { useAuth } from "../contexts/AuthContext";
 import ImageDropZone from "./ImageDropZone";
 import EnemyFields from "./EnemyFields";
 import { PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import LoginPrompt from "./LoginPrompt";
 import type { Enemy } from "../types";
 
 const AddEnemy: React.FC = () => {
@@ -20,12 +20,6 @@ const AddEnemy: React.FC = () => {
   const user = useAuth();
   const formRef = useRef<HTMLFormElement | null>(null);
 
-  const login = async () => {
-    const provider = new GoogleAuthProvider();
-    await signInWithPopup(auth, provider);
-    setLoginPrompt(false);
-    setIsOpen(true);
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,27 +68,12 @@ const AddEnemy: React.FC = () => {
 
   if (loginPrompt) {
     return (
-      <div
-        role="button"
-        tabIndex={-1}
-        className="fixed inset-0 z-50 p-5 bg-black flex items-center justify-center"
-        onClick={() => setLoginPrompt(false)}
-      >
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-        <div
-          role="dialog"
-          onClick={(e) => e.stopPropagation()}
-          className="bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
-        >
-          <p>Для добавления врага необходима авторизация</p>
-          <button
-            onClick={login}
-            className="px-4 py-2 bg-neonBlue text-darkBg font-semibold rounded hover:bg-opacity-80 transition cursor-pointer"
-          >
-            Войти через Google
-          </button>
-        </div>
-      </div>
+      <LoginPrompt
+        open={loginPrompt}
+        onClose={() => setLoginPrompt(false)}
+        onSuccess={() => setIsOpen(true)}
+        message="Для добавления врага необходима авторизация"
+      />
     );
   }
 

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
 import { StarIcon as StarOutline } from "@heroicons/react/24/outline";
@@ -6,6 +6,7 @@ import { db } from "../firebase";
 import { useAuth } from "../contexts/AuthContext";
 import { useFixedTags } from "../contexts/TagContext";
 import type { Enemy, UserProfile } from "../types";
+import LoginPrompt from "./LoginPrompt";
 
 interface Props {
   index: number;
@@ -17,12 +18,16 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     const cardRef = useRef<HTMLDivElement | null>(null);
     const user = useAuth();
     const fixedTags = useFixedTags();
+    const [loginPrompt, setLoginPrompt] = useState(false);
 
     const liked = !!user && enemy.likedBy?.includes(user.uid);
 
     const toggleLike = async (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (!user || !enemy.id) return;
+        if (!user || !enemy.id) {
+            setLoginPrompt(true);
+            return;
+        }
         const ref = doc(db, "eotv-enemies", enemy.id);
         await updateDoc(ref, {
             likedBy: liked ? arrayRemove(user.uid) : arrayUnion(user.uid)
@@ -30,6 +35,14 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     };
 
     return (
+    <>
+    {loginPrompt && (
+        <LoginPrompt
+            open={loginPrompt}
+            onClose={() => setLoginPrompt(false)}
+            message="Для сохранения требуется авторизация"
+        />
+    )}
     <div
         key={enemy.id}
         ref={cardRef}
@@ -70,6 +83,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
         {/* 2nd image preload */}
         {enemy.imageURL2 && <img src={enemy.imageURL2} alt="Extra" className="hidden" />}
     </div>
+    </>
   );
 };
 

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -75,7 +75,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
         key={enemy.id}
         ref={cardRef}
         onClick={handleClickOutside}
-        className={`text-white shadow-lg cursor-pointer  overflow-hidden fixed z-50 inset-0 p-5 bg-black flex justify-center items-center`}
+        className={`text-white shadow-lg cursor-pointer  overflow-hidden fixed z-40 inset-0 p-5 bg-black flex justify-center items-center`}
     >
        {(isEditing 
             ? <EditEnemy enemy={enemy} onClose={() => setIsEditing(false)} />

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -7,6 +7,7 @@ import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 import { db } from "../firebase";
 import EditEnemy from "./EditEnemy";
 import type { Enemy, UserProfile } from "../types";
+import LoginPrompt from "./LoginPrompt";
 
 interface Props {
   enemy: Enemy;
@@ -20,10 +21,14 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     const user = useAuth();
     const cardRef = useRef<HTMLDivElement | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    const [loginPrompt, setLoginPrompt] = useState(false);
     const liked = !!user && enemy.likedBy?.includes(user.uid);
 
     const toggleLike = async () => {
-        if (!user || !enemy.id) return;
+        if (!user || !enemy.id) {
+            setLoginPrompt(true);
+            return;
+        }
         const ref = doc(db, "eotv-enemies", enemy.id);
         await updateDoc(ref, {
             likedBy: liked ? arrayRemove(user.uid) : arrayUnion(user.uid)
@@ -58,6 +63,14 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     };
   
     return (
+    <>
+    {loginPrompt && (
+        <LoginPrompt
+            open={loginPrompt}
+            onClose={() => setLoginPrompt(false)}
+            message="Для сохранения требуется авторизация"
+        />
+    )}
     <div
         key={enemy.id}
         ref={cardRef}
@@ -142,6 +155,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
             </> 
         )}
     </div>
+    </>
   );
 };
 

--- a/src/components/EnemyList.test.tsx
+++ b/src/components/EnemyList.test.tsx
@@ -1,10 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import EnemyList from './EnemyList';
-import { useAuth } from '../contexts/AuthContext';
-
-jest.mock('../contexts/AuthContext', () => ({
-  useAuth: jest.fn()
-}));
 
 jest.mock('./AddEnemy', () => () => <div data-testid="add-enemy" />);
 import type { Enemy } from '../types';
@@ -14,20 +9,12 @@ jest.mock('./EnemyCard', () => ({ index, enemy, onClick }: { index: number; enem
 ));
 
 describe('EnemyList', () => {
-  it('shows AddEnemy when user logged in', () => {
-    (useAuth as jest.Mock).mockReturnValue({ uid: '1' });
+  it('renders AddEnemy', () => {
     render(<EnemyList enemies={[]} users={{}} onSelect={jest.fn()} />);
     expect(screen.getByTestId('add-enemy')).toBeInTheDocument();
   });
 
-  it('hides AddEnemy when user not logged in', () => {
-    (useAuth as jest.Mock).mockReturnValue(null);
-    render(<EnemyList enemies={[]} users={{}} onSelect={jest.fn()} />);
-    expect(screen.queryByTestId('add-enemy')).toBeNull();
-  });
-
   it('renders enemy cards and handles selection', () => {
-    (useAuth as jest.Mock).mockReturnValue(null);
     const enemies = [{
       id: '1',
       name: 'E1',

--- a/src/components/EnemyList.tsx
+++ b/src/components/EnemyList.tsx
@@ -1,7 +1,6 @@
 import AddEnemy from "./AddEnemy";
 import EnemyCard from "./EnemyCard";
 import type { Enemy, UserProfile } from "../types";
-import { useAuth } from "../contexts/AuthContext";
 
 interface Props {
   enemies: Enemy[];
@@ -10,11 +9,9 @@ interface Props {
 }
 
 const EnemyList: React.FC<Props> = ({ enemies, users, onSelect }) => {
-  const user = useAuth();
-
   return (
     <div className="flex flex-wrap gap-4 justify-center relative">
-      {user && <AddEnemy />}
+      <AddEnemy />
       {enemies.map((enemy, index) => (
         <EnemyCard
           index={index}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,4 +1,5 @@
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { auth } from "../firebase";
 
 interface Props {
@@ -29,8 +30,14 @@ const LoginPrompt: React.FC<Props> = ({ open, message = "Для продолже
       <div
         role="dialog"
         onClick={(e) => e.stopPropagation()}
-        className="bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
+        className="relative bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
       >
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-300 hover:text-white cursor-pointer"
+        >
+          <XMarkIcon className="w-5 h-5" />
+        </button>
         <p>{message}</p>
         <button
           onClick={login}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -23,7 +23,7 @@ const LoginPrompt: React.FC<Props> = ({ open, message = "Для продолже
     <div
       role="button"
       tabIndex={-1}
-      className="fixed inset-0 z-50 p-5 bg-black flex items-center justify-center"
+      className="fixed inset-0 z-[60] p-5 bg-black flex items-center justify-center"
       onClick={onClose}
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,0 +1,46 @@
+import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { auth } from "../firebase";
+
+interface Props {
+  open: boolean;
+  message?: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const LoginPrompt: React.FC<Props> = ({ open, message = "Для продолжения необходима авторизация", onClose, onSuccess }) => {
+  if (!open) return null;
+
+  const login = async () => {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(auth, provider);
+    onClose();
+    if (onSuccess) onSuccess();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={-1}
+      className="fixed inset-0 z-50 p-5 bg-black flex items-center justify-center"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        role="dialog"
+        onClick={(e) => e.stopPropagation()}
+        className="bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
+      >
+        <p>{message}</p>
+        <button
+          onClick={login}
+          className="px-4 py-2 bg-neonBlue text-darkBg font-semibold rounded hover:bg-opacity-80 transition cursor-pointer"
+        >
+          Войти через Google
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPrompt;


### PR DESCRIPTION
## Summary
- show "Add Enemy" button for all users
- centralize login dialog into `LoginPrompt`
- prompt login when adding an enemy or starring enemies
- update tests for new AddEnemy visibility

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6841a8cf15348324abfee8d4560e7a1c