### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -82,7 +82,7 @@ const AddEnemy: React.FC = () => {
       <div
         role="button"
         tabIndex={0}
-        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-40 h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
+        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
         onClick={() => {
           if (user) {
             setIsOpen(true);
@@ -118,9 +118,9 @@ const AddEnemy: React.FC = () => {
         <div
           role="dialog"
           onClick={(e) => e.stopPropagation()}
-          className="relative bg-gray-900 rounded-2xl w-full max-w-7xl flex shadow-lg overflow-hidden h-full"
+          className="relative bg-gray-900 rounded-2xl w-full max-w-7xl flex flex-col sm:flex-row shadow-lg overflow-hidden h-full"
         >
-        <form ref={formRef} onSubmit={handleSubmit} className="flex w-full h-full">
+        <form ref={formRef} onSubmit={handleSubmit} className="flex flex-col sm:flex-row w-full h-full overflow-y-auto">
         <ImageDropZone imageURL={imageURL} setImageURL={setImageURL} ownerUid={user?.uid || ""} />
         <EnemyFields
           name={name}

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -82,7 +82,7 @@ const AddEnemy: React.FC = () => {
       <div
         role="button"
         tabIndex={0}
-        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
+        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
         onClick={() => {
           if (user) {
             setIsOpen(true);

--- a/src/components/EditEnemy.tsx
+++ b/src/components/EditEnemy.tsx
@@ -51,7 +51,7 @@ const EditEnemy: React.FC<Props> = ({ enemy, onClose }) => {
 
 
   return (
-    <div className="relative bg-gray-900 rounded-2xl w-full flex shadow-lg h-full max-w-7xl overflow-hidden">
+    <div className="relative bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
       <ImageDropZone imageURL={imageURL} setImageURL={setImageURL} ownerUid={enemy.authorUid} />
       <EnemyFields
         name={name}

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -50,7 +50,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
         onClick={() => onClick(index)}
     >
         {/* 1st image */}
-        <img src={enemy.imageURL} alt={enemy.name} className="w-full h-40 sm:h-32 object-cover" />
+        <img src={enemy.imageURL} alt={enemy.name} className="w-full h-1/2 sm:h-32 object-cover" />
 
         <button
             onClick={toggleLike}

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -46,11 +46,11 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     <div
         key={enemy.id}
         ref={cardRef}
-        className={`bg-gray-800 text-white shadow-lg cursor-pointer  overflow-hidden relative w-40 h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
+        className={`bg-gray-800 text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
         onClick={() => onClick(index)}
     >
         {/* 1st image */}
-        <img src={enemy.imageURL} alt={enemy.name} className="w-full h-32 object-cover" />
+        <img src={enemy.imageURL} alt={enemy.name} className="w-full h-40 sm:h-32 object-cover" />
 
         <button
             onClick={toggleLike}

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -81,11 +81,11 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
             ? <EditEnemy enemy={enemy} onClose={() => setIsEditing(false)} />
             : <>
                 {/* Expanded view */}
-                <div className="relative bg-gray-900 rounded-2xl w-full flex shadow-lg h-full max-w-7xl overflow-hidden">
+                <div className="relative bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
                     {/* Left column - image 1 */}
-                    <img src={enemy.imageURL} alt={enemy.name} className="w-3/14 object-cover" />
+                    <img src={enemy.imageURL} alt={enemy.name} className="w-full sm:w-3/14 h-40 sm:h-auto object-cover" />
                     {/* Center - title + description */}
-                    <div className="w-4/7 flex flex-col px-6 overflow-y-auto">
+                    <div className="sm:w-4/7 w-full flex flex-col px-6 overflow-y-auto">
                         <h2 className="text-2xl font-bold text-center p-6 pt-10">{enemy.name}</h2>
                         <ReactMarkdown
                         components={{
@@ -101,7 +101,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
 
                     </div>
                     {/* Right column - image 2 */}
-                    {enemy.imageURL2 && <img src={enemy.imageURL2} alt="Extra" className="w-3/14 object-cover" />}
+                    {enemy.imageURL2 && <img src={enemy.imageURL2} alt="Extra" className="w-full sm:w-3/14 h-40 sm:h-auto object-cover" />}
 
                     {/* Tags */}
                     <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">

--- a/src/components/EnemyFields.tsx
+++ b/src/components/EnemyFields.tsx
@@ -24,7 +24,7 @@ const EnemyFields: FC<Props> = ({
   setCustomTags,
   children,
 }) => (
-  <div className="w-4/7 flex flex-col px-6 h-full overflow-y-auto">
+  <div className="w-full sm:w-4/7 flex flex-col px-6 h-full overflow-y-auto">
     <input
       type="text"
       placeholder="Имя противника"

--- a/src/components/EnemyList.tsx
+++ b/src/components/EnemyList.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const EnemyList: React.FC<Props> = ({ enemies, users, onSelect }) => {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 justify-center relative">
+    <div className="grid sm:flex sm:flex-wrap grid-cols-2 gap-4 justify-center relative">
       <AddEnemy />
       {enemies.map((enemy, index) => (
         <EnemyCard

--- a/src/components/EnemyList.tsx
+++ b/src/components/EnemyList.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const EnemyList: React.FC<Props> = ({ enemies, users, onSelect }) => {
   return (
-    <div className="flex flex-wrap gap-4 justify-center relative">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 justify-center relative">
       <AddEnemy />
       {enemies.map((enemy, index) => (
         <EnemyCard

--- a/src/components/ImageDropZone.tsx
+++ b/src/components/ImageDropZone.tsx
@@ -24,7 +24,7 @@ const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, class
 
   return (
     <div
-      className={`w-3/14 flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ""}`}
+      className={`w-full sm:w-3/14 flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ""}`}
       onDrop={onDrop}
       onDragOver={(e) => e.preventDefault()}
     >


### PR DESCRIPTION
## Summary
- adjust enemy list to use responsive grid
- resize enemy cards based on screen size
- make detail dialog stack vertically on small screens
- update add/edit forms for mobile
- tweak shared field and dropzone styles

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b92f5c848324bdcfc8a81927760e