### PR TITLE
Add dark/light theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       window.process = process;
     </script>
   </head>
-  <body>
+  <body class="bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,7 @@ const App: React.FC = () => {
   }, [selectedEnemy]);
 
   return (
-    <div className="bg-slate-900 text-sky-200 min-h-screen">
+    <div className="bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-sky-200 min-h-screen">
       <Header />
       <main className="p-6 max-w-screen-xl mx-auto">
         <h2 className="text-3xl font-bold text-center">Каталог противников для игры Грань Вселенной</h2>

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -82,7 +82,7 @@ const AddEnemy: React.FC = () => {
       <div
         role="button"
         tabIndex={0}
-        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
+        className="group relative flex flex-col items-center justify-center bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
         onClick={() => {
           if (user) {
             setIsOpen(true);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -61,7 +61,7 @@ const Auth: React.FC = () => {
         <>
           <button
             onClick={() => setMenuOpen(!menuOpen)}
-            className="flex items-center gap-2 focus:outline-none hover:bg-gray-700 rounded px-2 py-1 cursor-pointer"
+            className="flex items-center gap-2 focus:outline-none hover:bg-gray-300 dark:hover:bg-gray-700 rounded px-2 py-1 cursor-pointer"
           >
             <img
               src={
@@ -76,18 +76,18 @@ const Auth: React.FC = () => {
           {menuOpen && (
             <div
               ref={menuRef}
-              className="absolute right-0 top-full mt-2 w-40 bg-gray-800 rounded shadow-lg text-sm"
+              className="absolute right-0 top-full mt-2 w-40 bg-gray-100 dark:bg-gray-800 rounded shadow-lg text-sm"
             >
               <button
                 onClick={openProfile}
-                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-700 cursor-pointer"
+                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-300 dark:hover:bg-gray-700 cursor-pointer"
               >
                 <Cog6ToothIcon className="w-5 h-5" />
                 Настройки
               </button>
               <button
                 onClick={logout}
-                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-700 text-red-400 cursor-pointer"
+                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-300 dark:hover:bg-gray-700 text-red-400 cursor-pointer"
               >
                 <ArrowLeftOnRectangleIcon className="w-5 h-5" />
                 Выход

--- a/src/components/AvatarDropZone.tsx
+++ b/src/components/AvatarDropZone.tsx
@@ -24,7 +24,7 @@ const AvatarDropZone: React.FC<Props> = ({ avatarURL, setAvatarURL, ownerUid, cl
 
   return (
     <div
-      className={`flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ''}`}
+      className={`flex items-center justify-center bg-gray-200 dark:bg-gray-800 relative overflow-hidden group ${className || ''}`}
       onDrop={onDrop}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -46,7 +46,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     <div
         key={enemy.id}
         ref={cardRef}
-        className={`bg-gray-800 text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
+        className={`bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
         onClick={() => onClick(index)}
     >
         {/* 1st image */}

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -120,7 +120,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">
                         <div className="flex flex-wrap gap-1">
                         {enemy.tags.map((tag, index) => (
-                            <span key={index} className="bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
+                            <span key={index} className="bg-gray-300 dark:bg-gray-700 text-gray-900 dark:text-white px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
                         ))}
                         </div>
                     </div>
@@ -159,7 +159,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                         )}
                     </div>
                     {linkCopied && (
-                        <div className="absolute top-10 right-10 bg-gray-800 text-white text-xs px-2 py-1 rounded-md shadow">
+                        <div className="absolute top-10 right-10 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white text-xs px-2 py-1 rounded-md shadow">
                             Ссылка скопирована
                         </div>
                     )}
@@ -170,10 +170,10 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     </button>
 
                     {/* Navigation between cards */}
-                    <button className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onPrev}>
+                    <button className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-300 dark:bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onPrev}>
                         <ChevronLeftIcon className="w-5 h-5 text-white" />
                     </button>
-                    <button className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onNext}>
+                    <button className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-300 dark:bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onNext}>
                         <ChevronRightIcon className="w-5 h-5 text-white" />
                     </button>
                 </div>

--- a/src/components/EnemyFilters.tsx
+++ b/src/components/EnemyFilters.tsx
@@ -51,7 +51,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         placeholder="Поиск"
         value={search}
         onChange={e => setSearch(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white flex-1 h-10"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white flex-1 h-10"
       />
       <button
         type="button"
@@ -65,7 +65,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
       <select
         value={tag}
         onChange={e => setTag(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white h-10 hover:bg-gray-500 transition cursor-pointer"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white h-10 hover:bg-gray-300 dark:hover:bg-gray-500 transition cursor-pointer"
       >
         <option value="">Тег</option>
         {fixedTags.map(t => (
@@ -76,7 +76,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         <button
           type="button"
           onClick={() => setAuthorOpen(o => !o)}
-          className="p-2 rounded bg-gray-700 text-white flex items-center gap-2 h-10 hover:bg-gray-500 transition cursor-pointer"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white flex items-center gap-2 h-10 hover:bg-gray-300 dark:hover:bg-gray-500 transition cursor-pointer"
         >
           {authorProfile && <img src={authorProfile.photoURL} alt="avatar" className="w-6 h-6 rounded-full" />}
           <span>{authorProfile ? authorProfile.displayName : 'Автор'}</span>
@@ -84,10 +84,10 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         {authorOpen && (
           <div
             ref={panelRef}
-            className="absolute left-0 z-10 bg-gray-800 rounded shadow p-2 mt-1 max-h-60 overflow-y-auto w-48"
+            className="absolute left-0 z-10 bg-gray-100 dark:bg-gray-800 rounded shadow p-2 mt-1 max-h-60 overflow-y-auto w-48"
           >
             <div
-              className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2"
+              className="cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700 p-1 flex items-center gap-2"
               onClick={() => {
                 setAuthor('');
                 setAuthorOpen(false);
@@ -98,7 +98,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
             {Object.entries(authors).map(([uid, prof]) => (
               <div
                 key={uid}
-                className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2"
+                className="cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700 p-1 flex items-center gap-2"
                 onClick={() => {
                   setAuthor(uid);
                   setAuthorOpen(false);
@@ -125,11 +125,11 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         <XMarkIcon className="w-5 h-5" />
         Сбросить фильтры
       </button>
-      <span className="text-sm text-gray-300">Сортировка:</span>
+      <span className="text-sm text-gray-600 dark:text-gray-300">Сортировка:</span>
       <select
         value={sort}
         onChange={e => setSort(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white h-10 hover:bg-gray-500 transition cursor-pointer"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white h-10 hover:bg-gray-300 dark:hover:bg-gray-500 transition cursor-pointer"
       >
         <option value="name">Имя</option>
         <option value="date">Дата</option>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,22 @@
 import Auth from "./Auth";
+import ThemeSwitch from "./ThemeSwitch";
 
 const Header: React.FC = () => {
   return (
-    <header className="text-sky-300">
+    <header className="bg-slate-100 dark:bg-slate-900 text-sky-600 dark:text-sky-300">
       <div className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-2">
             <img src="./logo.png" alt="d320" className="w-10 h-10" />
-            <h1 className="text-2xl font-bold text-sky-300">d320</h1>
+            <h1 className="text-2xl font-bold">d320</h1>
           </div>
 
           {/* Userpic / Authorization */}
-          <Auth />
+          <div className="flex items-center gap-4">
+            <ThemeSwitch />
+            <Auth />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/ImageDropZone.tsx
+++ b/src/components/ImageDropZone.tsx
@@ -24,7 +24,7 @@ const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, class
 
   return (
     <div
-      className={`w-full sm:w-3/14 flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ""}`}
+      className={`w-full sm:w-3/14 flex items-center justify-center bg-gray-200 dark:bg-gray-800 relative overflow-hidden group ${className || ""}`}
       onDrop={onDrop}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -30,7 +30,7 @@ const LoginPrompt: React.FC<Props> = ({ open, message = "Для продолже
       <div
         role="dialog"
         onClick={(e) => e.stopPropagation()}
-        className="relative bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
+        className="relative bg-gray-200 dark:bg-gray-900 text-gray-900 dark:text-white rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
       >
         <button
           onClick={onClose}

--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -59,7 +59,7 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
         ref={formRef}
         role="dialog"
         onClick={(e) => e.stopPropagation()}
-        className="relative bg-gray-900 rounded-2xl w-full max-w-md flex flex-col shadow-lg overflow-hidden p-6 items-center"
+        className="relative bg-gray-200 dark:bg-gray-900 text-gray-900 dark:text-white rounded-2xl w-full max-w-md flex flex-col shadow-lg overflow-hidden p-6 items-center"
       >
         <AvatarDropZone
           avatarURL={photoURL}

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -15,7 +15,7 @@ const ThemeSwitch: React.FC = () => {
       <SunIcon className="absolute left-1 w-4 h-4 text-yellow-500" />
       <MoonIcon className="absolute right-1 w-4 h-4 text-yellow-300" />
       <span
-        className={`absolute bg-white w-4 h-4 rounded-full transition-transform ${knobPosition}`}
+        className={`absolute bg-white w-4 h-4 rounded-full transition-transform transform ${knobPosition}`}
       />
     </button>
   );

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -9,6 +9,7 @@ const ThemeSwitch: React.FC = () => {
   return (
     <button
       aria-label="Toggle theme"
+      aria-pressed={theme === 'dark'}
       onClick={toggleTheme}
       className="relative w-12 h-6 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center transition-colors"
     >

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -1,0 +1,24 @@
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid';
+import { useTheme } from '../contexts/ThemeContext';
+
+const ThemeSwitch: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  const knobPosition = theme === 'dark' ? 'translate-x-6' : 'translate-x-1';
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className="relative w-12 h-6 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center transition-colors"
+    >
+      <SunIcon className="absolute left-1 w-4 h-4 text-yellow-500" />
+      <MoonIcon className="absolute right-1 w-4 h-4 text-yellow-300" />
+      <span
+        className={`absolute bg-white w-4 h-4 rounded-full transition-transform ${knobPosition}`}
+      />
+    </button>
+  );
+};
+
+export default ThemeSwitch;

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeValue>({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.css
+++ b/src/index.css
@@ -10,8 +10,6 @@ html, body {
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: oklch(0.21 0.034 264.665);
-  color: #f3f4f6;
 }
 
 code {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html, body {
   margin: 0;
@@ -14,9 +14,6 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-body {
-  @apply bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100;
-}
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 html, body {
   margin: 0;
@@ -10,6 +12,10 @@ html, body {
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100;
 }
 
 code {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,15 +5,18 @@ import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
 import { TagProvider } from './contexts/TagContext';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <AuthProvider>
-      <TagProvider>
-        <App />
-      </TagProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <TagProvider>
+          <App />
+        </TagProvider>
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- implement ThemeContext and slider switcher
- use Tailwind `dark` mode with configuration
- wrap app with ThemeProvider
- update header with switcher
- adapt default styles for light theme

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6841c7c2f4248324902a72d123d5af1d