### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
@@ -30,6 +30,14 @@
       import process from 'process';
       window.Buffer = Buffer;
       window.process = process;
+    </script>
+    <script>
+      const saved = localStorage.getItem('theme');
+      if (saved === 'light') {
+        document.documentElement.classList.remove('dark');
+      } else {
+        document.documentElement.classList.add('dark');
+      }
     </script>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,7 @@ const App: React.FC = () => {
   }, [selectedEnemy]);
 
   return (
-    <div className="bg-slate-900 text-sky-200 min-h-screen">
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-slate-900 dark:text-sky-200">
       <Header />
       <main className="p-6 max-w-screen-xl mx-auto">
         <h2 className="text-3xl font-bold text-center">Каталог противников для игры Грань Вселенной</h2>

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -82,7 +82,7 @@ const AddEnemy: React.FC = () => {
       <div
         role="button"
         tabIndex={0}
-        className="group relative flex flex-col items-center justify-center bg-gray-800 text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
+        className="group relative flex flex-col items-center justify-center bg-white text-gray-900 dark:bg-gray-800 dark:text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
         onClick={() => {
           if (user) {
             setIsOpen(true);
@@ -118,7 +118,7 @@ const AddEnemy: React.FC = () => {
         <div
           role="dialog"
           onClick={(e) => e.stopPropagation()}
-          className="relative bg-gray-900 rounded-2xl w-full max-w-7xl flex flex-col sm:flex-row shadow-lg overflow-hidden h-full"
+          className="relative bg-white dark:bg-gray-900 rounded-2xl w-full max-w-7xl flex flex-col sm:flex-row shadow-lg overflow-hidden h-full"
         >
         <form ref={formRef} onSubmit={handleSubmit} className="flex flex-col sm:flex-row w-full h-full overflow-y-auto">
         <ImageDropZone imageURL={imageURL} setImageURL={setImageURL} ownerUid={user?.uid || ""} />
@@ -136,7 +136,7 @@ const AddEnemy: React.FC = () => {
             <button
               type="button"
               onClick={() => setIsOpen(false)}
-              className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition cursor-pointer"
+              className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-white rounded hover:bg-gray-200 dark:hover:bg-gray-500 transition cursor-pointer"
             >
               <XMarkIcon className="w-5 h-5" />
               Отмена

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -61,7 +61,7 @@ const Auth: React.FC = () => {
         <>
           <button
             onClick={() => setMenuOpen(!menuOpen)}
-            className="flex items-center gap-2 focus:outline-none hover:bg-gray-700 rounded px-2 py-1 cursor-pointer"
+            className="flex items-center gap-2 focus:outline-none hover:bg-gray-200 dark:hover:bg-gray-700 rounded px-2 py-1 cursor-pointer"
           >
             <img
               src={
@@ -76,18 +76,18 @@ const Auth: React.FC = () => {
           {menuOpen && (
             <div
               ref={menuRef}
-              className="absolute right-0 top-full mt-2 w-40 bg-gray-800 rounded shadow-lg text-sm"
+              className="absolute right-0 top-full mt-2 w-40 bg-white dark:bg-gray-800 rounded shadow-lg text-sm"
             >
               <button
                 onClick={openProfile}
-                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-700 cursor-pointer"
+                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
               >
                 <Cog6ToothIcon className="w-5 h-5" />
                 Настройки
               </button>
               <button
                 onClick={logout}
-                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-700 text-red-400 cursor-pointer"
+                className="w-full flex items-center gap-2 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 text-red-400 cursor-pointer"
               >
                 <ArrowLeftOnRectangleIcon className="w-5 h-5" />
                 Выход

--- a/src/components/AvatarDropZone.tsx
+++ b/src/components/AvatarDropZone.tsx
@@ -24,7 +24,7 @@ const AvatarDropZone: React.FC<Props> = ({ avatarURL, setAvatarURL, ownerUid, cl
 
   return (
     <div
-      className={`flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ''}`}
+      className={`flex items-center justify-center bg-gray-200 dark:bg-gray-800 relative overflow-hidden group ${className || ''}`}
       onDrop={onDrop}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/src/components/EditEnemy.tsx
+++ b/src/components/EditEnemy.tsx
@@ -51,7 +51,7 @@ const EditEnemy: React.FC<Props> = ({ enemy, onClose }) => {
 
 
   return (
-    <div className="relative bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
+    <div className="relative bg-white dark:bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
       <ImageDropZone imageURL={imageURL} setImageURL={setImageURL} ownerUid={enemy.authorUid} />
       <EnemyFields
         name={name}

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -46,7 +46,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
     <div
         key={enemy.id}
         ref={cardRef}
-        className={`bg-gray-800 text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
+        className={`bg-white text-gray-900 dark:bg-gray-800 dark:text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
         onClick={() => onClick(index)}
     >
         {/* 1st image */}
@@ -68,7 +68,7 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
             <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">
                 <div className="flex flex-wrap gap-1">
                 {enemy.tags.filter(tag => fixedTags.includes(tag)).map((tag, index) => (
-                    <span key={index} className="bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
+                    <span key={index} className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
                 ))}
                 </div>
             </div>

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -94,7 +94,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
             ? <EditEnemy enemy={enemy} onClose={() => setIsEditing(false)} />
             : <>
                 {/* Expanded view */}
-                <div className="relative bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
+                <div className="relative bg-white dark:bg-gray-900 rounded-2xl w-full flex flex-col sm:flex-row shadow-lg h-full max-w-7xl overflow-hidden">
                     {/* Left column - image 1 */}
                     <img src={enemy.imageURL} alt={enemy.name} className="w-full sm:w-3/14 h-40 sm:h-auto object-cover" />
                     {/* Center - title + description */}
@@ -120,7 +120,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     <div className="absolute bottom-4 left-4 flex flex-col items-end gap-2">
                         <div className="flex flex-wrap gap-1">
                         {enemy.tags.map((tag, index) => (
-                            <span key={index} className="bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
+                            <span key={index} className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded text-xs drop-shadow-2xl">{tag}</span>
                         ))}
                         </div>
                     </div>
@@ -159,7 +159,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                         )}
                     </div>
                     {linkCopied && (
-                        <div className="absolute top-10 right-10 bg-gray-800 text-white text-xs px-2 py-1 rounded-md shadow">
+                        <div className="absolute top-10 right-10 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white text-xs px-2 py-1 rounded-md shadow">
                             Ссылка скопирована
                         </div>
                     )}
@@ -170,10 +170,10 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     </button>
 
                     {/* Navigation between cards */}
-                    <button className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onPrev}>
+                    <button className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-200 dark:bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onPrev}>
                         <ChevronLeftIcon className="w-5 h-5 text-white" />
                     </button>
-                    <button className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onNext}>
+                    <button className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-200 dark:bg-gray-700 p-2 rounded-full cursor-pointer hover:scale-110 transition-all duration-300 ease-in-out" onClick={onNext}>
                         <ChevronRightIcon className="w-5 h-5 text-white" />
                     </button>
                 </div>

--- a/src/components/EnemyFields.tsx
+++ b/src/components/EnemyFields.tsx
@@ -30,14 +30,14 @@ const EnemyFields: FC<Props> = ({
       placeholder="Имя противника"
       value={name}
       onChange={(e) => setName(e.target.value)}
-      className="w-full p-2 mt-4 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
+      className="w-full p-2 mt-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
       required
     />
     <textarea
       placeholder="Описание"
       value={customDescription}
       onChange={(e) => setCustomDescription(e.target.value)}
-      className="w-full p-2 mt-4 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue flex-1 resize-none"
+      className="w-full p-2 mt-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue flex-1 resize-none"
     />
     <TagBox
       selectedTags={selectedTags}

--- a/src/components/EnemyFilters.tsx
+++ b/src/components/EnemyFilters.tsx
@@ -51,7 +51,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         placeholder="Поиск"
         value={search}
         onChange={e => setSearch(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white flex-1 h-10"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white flex-1 h-10"
       />
       <button
         type="button"
@@ -65,7 +65,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
       <select
         value={tag}
         onChange={e => setTag(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white h-10 hover:bg-gray-500 transition cursor-pointer"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white h-10 hover:bg-gray-100 dark:hover:bg-gray-500 transition cursor-pointer"
       >
         <option value="">Тег</option>
         {fixedTags.map(t => (
@@ -76,7 +76,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         <button
           type="button"
           onClick={() => setAuthorOpen(o => !o)}
-          className="p-2 rounded bg-gray-700 text-white flex items-center gap-2 h-10 hover:bg-gray-500 transition cursor-pointer"
+          className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white flex items-center gap-2 h-10 hover:bg-gray-100 dark:hover:bg-gray-500 transition cursor-pointer"
         >
           {authorProfile && <img src={authorProfile.photoURL} alt="avatar" className="w-6 h-6 rounded-full" />}
           <span>{authorProfile ? authorProfile.displayName : 'Автор'}</span>
@@ -84,10 +84,10 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         {authorOpen && (
           <div
             ref={panelRef}
-            className="absolute left-0 z-10 bg-gray-800 rounded shadow p-2 mt-1 max-h-60 overflow-y-auto w-48"
+            className="absolute left-0 z-10 bg-white dark:bg-gray-800 rounded shadow p-2 mt-1 max-h-60 overflow-y-auto w-48"
           >
             <div
-              className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2"
+              className="cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700 p-1 flex items-center gap-2"
               onClick={() => {
                 setAuthor('');
                 setAuthorOpen(false);
@@ -98,7 +98,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
             {Object.entries(authors).map(([uid, prof]) => (
               <div
                 key={uid}
-                className="cursor-pointer hover:bg-gray-700 p-1 flex items-center gap-2"
+                className="cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700 p-1 flex items-center gap-2"
                 onClick={() => {
                   setAuthor(uid);
                   setAuthorOpen(false);
@@ -129,7 +129,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
       <select
         value={sort}
         onChange={e => setSort(e.target.value)}
-        className="p-2 rounded bg-gray-700 text-white h-10 hover:bg-gray-500 transition cursor-pointer"
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white h-10 hover:bg-gray-100 dark:hover:bg-gray-500 transition cursor-pointer"
       >
         <option value="name">Имя</option>
         <option value="date">Дата</option>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Footer: React.FC = () => (
-  <footer className="text-center text-gray-400 p-4 flex items-center justify-center gap-2">
+  <footer className="text-center text-gray-600 dark:text-gray-400 p-4 flex items-center justify-center gap-2">
     <span>Eugen Zha</span>
     <a href="https://t.me/d320stories" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 link">
       <img src="./telegram.svg" alt="Telegram" className="w-5 h-5" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,21 @@
 import Auth from "./Auth";
+import ThemeToggle from "./ThemeToggle";
 
 const Header: React.FC = () => {
   return (
-    <header className="text-sky-300">
+    <header className="text-gray-900 dark:text-sky-300">
       <div className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-2">
             <img src="./logo.png" alt="d320" className="w-10 h-10" />
-            <h1 className="text-2xl font-bold text-sky-300">d320</h1>
+            <h1 className="text-2xl font-bold text-blue-700 dark:text-sky-300">d320</h1>
           </div>
 
-          {/* Userpic / Authorization */}
-          <Auth />
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Auth />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/ImageDropZone.tsx
+++ b/src/components/ImageDropZone.tsx
@@ -24,7 +24,7 @@ const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, class
 
   return (
     <div
-      className={`w-full sm:w-3/14 flex items-center justify-center bg-gray-800 relative overflow-hidden group ${className || ""}`}
+      className={`w-full sm:w-3/14 flex items-center justify-center bg-gray-200 dark:bg-gray-800 relative overflow-hidden group ${className || ""}`}
       onDrop={onDrop}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -30,7 +30,7 @@ const LoginPrompt: React.FC<Props> = ({ open, message = "Для продолже
       <div
         role="dialog"
         onClick={(e) => e.stopPropagation()}
-        className="relative bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
+        className="relative bg-white dark:bg-gray-900 rounded-2xl w-full max-w-sm p-6 flex flex-col items-center gap-4"
       >
         <button
           onClick={onClose}

--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -59,7 +59,7 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
         ref={formRef}
         role="dialog"
         onClick={(e) => e.stopPropagation()}
-        className="relative bg-gray-900 rounded-2xl w-full max-w-md flex flex-col shadow-lg overflow-hidden p-6 items-center"
+        className="relative bg-white dark:bg-gray-900 rounded-2xl w-full max-w-md flex flex-col shadow-lg overflow-hidden p-6 items-center"
       >
         <AvatarDropZone
           avatarURL={photoURL}
@@ -71,13 +71,13 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
           type="text"
           value={displayName}
           onChange={(e) => setDisplayName(e.target.value)}
-          className="w-full p-2 mt-4 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
+          className="w-full p-2 mt-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
         />
         <div className="flex gap-4 mt-6 w-full">
           <button
             type="button"
             onClick={onClose}
-            className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition cursor-pointer"
+            className="flex-1 flex items-center justify-center gap-1 px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-white rounded hover:bg-gray-200 dark:hover:bg-gray-500 transition cursor-pointer"
           >
             <XMarkIcon className="w-5 h-5" />
             Отмена

--- a/src/components/TagBox.tsx
+++ b/src/components/TagBox.tsx
@@ -43,9 +43,9 @@ const TagBox: React.FC<Props> = ({ selectedTags, setSelectedTags, customTags, se
   return (
     <div className="mt-auto py-4">
       <label className="block text-sm mb-1">Теги</label>
-      <div className="flex flex-wrap gap-1 bg-gray-700 p-2 rounded">
+      <div className="flex flex-wrap gap-1 bg-gray-200 dark:bg-gray-700 p-2 rounded">
         {selectedTags.map(tag => (
-          <span key={tag} className="bg-gray-600 px-2 py-1 rounded text-xs flex items-center gap-1">
+          <span key={tag} className="bg-gray-300 dark:bg-gray-600 px-2 py-1 rounded text-xs flex items-center gap-1">
             {tag}
             <button type="button" onClick={() => removeTag(tag)} className="text-red-400 hover:text-white">×</button>
           </span>
@@ -56,7 +56,7 @@ const TagBox: React.FC<Props> = ({ selectedTags, setSelectedTags, customTags, se
           list="tag-suggestions"
           onChange={e => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="bg-transparent outline-none flex-1 text-sm text-white"
+          className="bg-transparent outline-none flex-1 text-sm text-gray-900 dark:text-white"
         />
         <datalist id="tag-suggestions">
           {filteredSuggestions.map(tag => (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { SunIcon, MoonIcon } from "@heroicons/react/24/solid";
+
+const ThemeToggle: React.FC = () => {
+  const [dark, setDark] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light') {
+      document.documentElement.classList.remove('dark');
+      setDark(false);
+    } else {
+      document.documentElement.classList.add('dark');
+      setDark(true);
+    }
+  }, []);
+
+  const toggle = () => {
+    if (dark) {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    } else {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    }
+    setDark(!dark);
+  };
+
+  return (
+    <label className="relative inline-flex items-center cursor-pointer">
+      <input
+        type="checkbox"
+        className="sr-only peer"
+        checked={!dark}
+        onChange={toggle}
+      />
+      <div className="w-12 h-6 bg-gray-300 rounded-full peer-focus:ring-2 peer-focus:ring-blue-500 dark:bg-gray-600">
+        <SunIcon className="absolute left-1 top-1 w-4 h-4 text-yellow-400" />
+        <MoonIcon className="absolute right-1 top-1 w-4 h-4 text-blue-400" />
+        <div className="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-6" />
+      </div>
+    </label>
+  );
+};
+
+export default ThemeToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -10,8 +10,8 @@ html, body {
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: oklch(0.21 0.034 264.665);
-  color: #f3f4f6;
+
+  @apply bg-gray-50 text-gray-900 dark:bg-slate-900 dark:text-sky-200;
 }
 
 code {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- implement `ThemeToggle` slider with sun and moon icons
- enable dark mode class strategy and default to dark
- update global styles and header to toggle theme
- adjust component colors for light theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d70837f88324b0a39833085f6a10