### PR TITLE
Add printing options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import EnemyFilters from "./components/EnemyFilters";
 import type { Enemy, UserProfile } from "./types";
 import { useAuth } from "./contexts/AuthContext";
 import { fetchUserProfiles } from "./utils/fetchUserProfiles";
+import { printEnemies } from "./utils/printEnemies";
 
 const App: React.FC = () => {
   const [enemies, setEnemies] = useState<Enemy[]>([]);
@@ -47,6 +48,10 @@ const App: React.FC = () => {
       await deleteDoc(doc(db, "eotv-enemies", id));
       setSelectedIndex(null);
     }
+  };
+
+  const handlePrintAll = () => {
+    printEnemies(filtered, profiles);
   };
 
   const normalizedSearch = search.toLowerCase();
@@ -143,6 +148,7 @@ const App: React.FC = () => {
           sort={sort}
           setSort={setSort}
           authors={profiles}
+          onPrint={handlePrintAll}
         />
         <EnemyList enemies={filtered} users={profiles} onSelect={setSelectedIndex} />
       </main>

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import ReactMarkdown from "react-markdown";
-import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon, StarIcon as StarOutline, LinkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, PencilSquareIcon, TrashIcon, ChevronLeftIcon, ChevronRightIcon, StarIcon as StarOutline, LinkIcon, PrinterIcon } from "@heroicons/react/24/outline";
 import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
 import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 import { db } from "../firebase";
+import { printEnemies } from "../utils/printEnemies";
 import EditEnemy from "./EditEnemy";
 import type { Enemy, UserProfile } from "../types";
 import LoginPrompt from "./LoginPrompt";
@@ -46,6 +47,14 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
         } catch (e) {
             console.error('Failed to copy link', e);
         }
+    };
+
+    const handlePrint = () => {
+        const profiles: Record<string, UserProfile> = {};
+        if (author) {
+            profiles[enemy.authorUid] = author;
+        }
+        printEnemies([enemy], profiles);
     };
 
     useEffect(() => {
@@ -146,6 +155,13 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                             className="text-gray-300 hover:scale-110 transition"
                         >
                             <LinkIcon className="w-6 h-6" />
+                        </button>
+                        <button
+                            onClick={handlePrint}
+                            title="Печать"
+                            className="text-gray-300 hover:scale-110 transition"
+                        >
+                            <PrinterIcon className="w-6 h-6" />
                         </button>
                         {user && user.uid === enemy.authorUid && (
                             <>

--- a/src/components/EnemyFilters.tsx
+++ b/src/components/EnemyFilters.tsx
@@ -16,9 +16,10 @@ interface Props {
   sort: string;
   setSort: (v: string) => void;
   authors: Record<string, UserProfile>;
+  onPrint: () => void;
 }
 
-const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, setLiked, author, setAuthor, sort, setSort, authors }) => {
+const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, setLiked, author, setAuthor, sort, setSort, authors, onPrint }) => {
   const fixedTags = useFixedTags();
   const [authorOpen, setAuthorOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -134,6 +135,13 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
         <option value="name">Имя</option>
         <option value="date">Дата</option>
       </select>
+      <button
+        type="button"
+        onClick={onPrint}
+        className="ml-auto flex items-center gap-1 p-2 rounded border text-blue-700 dark:text-sky-300 hover:text-blue-500 dark:hover:text-sky-200 border-blue-700 dark:border-sky-300 hover:border-blue-500 dark:hover:border-sky-200 transition h-10 cursor-pointer"
+      >
+        Напечатать
+      </button>
     </div>
   );
 };

--- a/src/utils/printEnemies.ts
+++ b/src/utils/printEnemies.ts
@@ -1,0 +1,58 @@
+import type { Enemy, UserProfile } from "../types";
+
+export const printEnemies = (
+  enemies: Enemy[],
+  authors: Record<string, UserProfile>
+) => {
+  const styles = `
+    body { font-family: sans-serif; padding: 20px; }
+    .page { page-break-after: always; }
+    .page:last-child { page-break-after: auto; }
+    h1 { text-align: center; margin-bottom: 20px; }
+    .images { display: flex; gap: 10px; justify-content: center; margin-bottom: 20px; }
+    .desc { white-space: pre-wrap; margin-bottom: 20px; }
+    .tags { margin-bottom: 20px; }
+    .tags span { background: #eee; padding: 2px 4px; margin-right: 4px; border-radius: 3px; }
+    .author { text-align: right; }
+  `;
+
+  const pages = enemies
+    .map((enemy) => {
+      const author = authors[enemy.authorUid];
+      const tags = enemy.tags.map((t) => `<span>${t}</span>`).join(" ");
+      const desc = enemy.customDescription
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\n/g, "<br/>");
+      return `
+        <div class="page">
+          <h1>${enemy.name}</h1>
+          <div class="images">
+            <img src="${enemy.imageURL}" />
+            ${enemy.imageURL2 ? `<img src="${enemy.imageURL2}" />` : ""}
+          </div>
+          <div class="desc">${desc}</div>
+          <div class="tags">${tags}</div>
+          <div class="author">${author ? author.displayName : ""}</div>
+        </div>`;
+    })
+    .join("");
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Print</title>
+  <style>${styles}</style>
+</head>
+<body onload="window.print()">
+${pages}
+</body>
+</html>`;
+
+  const win = window.open("", "_blank");
+  if (!win) return;
+  win.document.write(html);
+  win.document.close();
+};


### PR DESCRIPTION
## Summary
- add `printEnemies` helper for generating printable HTML
- enable single enemy printing from detail view
- allow printing all filtered enemies from filter panel

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f4f8e14c832480ededc206f691dc