### PR TITLE
Fix arrow navigation while editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,16 @@ const App: React.FC = () => {
   useEffect(() => {
     if (selectedEnemy === null) return;
     const handleKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.closest('input') ||
+          target.closest('textarea') ||
+          target.closest('[contenteditable]'))
+      ) {
+        return;
+      }
+
       if (e.key === 'ArrowLeft') {
         handlePrev();
       } else if (e.key === 'ArrowRight') {


### PR DESCRIPTION
## Summary
- stop handling arrow keys while editing enemy details

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433136f55083249243776b5d952fa5