### PR TITLE
Add draft support for enemies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const App: React.FC = () => {
   const [liked, setLiked] = useState(false);
   const [author, setAuthor] = useState("");
   const [sort, setSort] = useState("name");
+  const [draftFilter, setDraftFilter] = useState("all");
   const user = useAuth();
 
   useEffect(() => {
@@ -56,9 +57,11 @@ const App: React.FC = () => {
 
   const normalizedSearch = search.toLowerCase();
   let filtered = enemies.filter(e =>
-    e.name.toLowerCase().includes(normalizedSearch) ||
-    e.customDescription.toLowerCase().includes(normalizedSearch) ||
-    e.tags.some(t => t.toLowerCase().includes(normalizedSearch))
+    (!e.draft || (user && e.authorUid === user.uid)) && (
+      e.name.toLowerCase().includes(normalizedSearch) ||
+      e.customDescription.toLowerCase().includes(normalizedSearch) ||
+      e.tags.some(t => t.toLowerCase().includes(normalizedSearch))
+    )
   );
   if (tag) {
     filtered = filtered.filter(e => e.tags.includes(tag));
@@ -68,6 +71,11 @@ const App: React.FC = () => {
   }
   if (author) {
     filtered = filtered.filter(e => e.authorUid === author);
+  }
+  if (draftFilter === 'draft') {
+    filtered = filtered.filter(e => e.draft);
+  } else if (draftFilter === 'published') {
+    filtered = filtered.filter(e => !e.draft);
   }
   filtered = [...filtered];
   if (sort === "name") {
@@ -160,6 +168,8 @@ const App: React.FC = () => {
           setLiked={setLiked}
           author={author}
           setAuthor={setAuthor}
+          draft={draftFilter}
+          setDraft={setDraftFilter}
           sort={sort}
           setSort={setSort}
           authors={profiles}

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../contexts/AuthContext";
 import ImageDropZone from "./ImageDropZone";
 import EnemyFields from "./EnemyFields";
 import { PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { PencilIcon, DocumentCheckIcon } from "@heroicons/react/24/solid";
+import DraftSwitch from "./DraftSwitch";
 import LoginPrompt from "./LoginPrompt";
 import type { Enemy } from "../types";
 
@@ -132,25 +132,8 @@ const AddEnemy: React.FC = () => {
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}
         >
-          <div className="flex gap-4 py-2 items-center">
-            <label className="flex items-center gap-1 cursor-pointer">
-              <input
-                type="radio"
-                name="draft"
-                checked={draft}
-                onChange={() => setDraft(true)}
-              />
-              <PencilIcon className="w-5 h-5" />Черновик
-            </label>
-            <label className="flex items-center gap-1 cursor-pointer">
-              <input
-                type="radio"
-                name="draft"
-                checked={!draft}
-                onChange={() => setDraft(false)}
-              />
-              <DocumentCheckIcon className="w-5 h-5" />Опубликовано
-            </label>
+          <div className="py-2">
+            <DraftSwitch draft={draft} setDraft={setDraft} />
           </div>
           <div className="flex gap-4 py-4">
             <button

--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../contexts/AuthContext";
 import ImageDropZone from "./ImageDropZone";
 import EnemyFields from "./EnemyFields";
 import { PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { PencilIcon, DocumentCheckIcon } from "@heroicons/react/24/solid";
 import LoginPrompt from "./LoginPrompt";
 import type { Enemy } from "../types";
 
@@ -16,6 +17,7 @@ const AddEnemy: React.FC = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [imageURL, setImageURL] = useState("");
   const [imageURL2, setImageURL2] = useState("");
+  const [draft, setDraft] = useState(true);
   const user = useAuth();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -32,6 +34,7 @@ const AddEnemy: React.FC = () => {
       authorUid: user.uid,
       likedBy: [],
       createdAt: new Date().toISOString(),
+      ...(draft ? { draft: true } : {})
     };
     await addDoc(enemiesCollection, newEnemy);
     setIsOpen(false);
@@ -40,6 +43,7 @@ const AddEnemy: React.FC = () => {
     setSelectedTags([]);
     setImageURL("");
     setImageURL2("");
+    setDraft(true);
   };
 
   useEffect(() => {
@@ -82,6 +86,7 @@ const AddEnemy: React.FC = () => {
         className="group relative flex flex-col items-center justify-center bg-white text-gray-900 dark:bg-gray-800 dark:text-white p-4 rounded-xl shadow-lg cursor-pointer w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 transition-all duration-300 ease-in-out"
         onClick={() => {
           if (user) {
+            setDraft(true);
             setIsOpen(true);
           } else {
             setLoginPrompt(true);
@@ -89,7 +94,7 @@ const AddEnemy: React.FC = () => {
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            if (user) setIsOpen(true); else setLoginPrompt(true);
+            if (user) { setDraft(true); setIsOpen(true); } else setLoginPrompt(true);
           }
         }}
       >
@@ -127,6 +132,26 @@ const AddEnemy: React.FC = () => {
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}
         >
+          <div className="flex gap-4 py-2 items-center">
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="draft"
+                checked={draft}
+                onChange={() => setDraft(true)}
+              />
+              <PencilIcon className="w-5 h-5" />Черновик
+            </label>
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="draft"
+                checked={!draft}
+                onChange={() => setDraft(false)}
+              />
+              <DocumentCheckIcon className="w-5 h-5" />Опубликовано
+            </label>
+          </div>
           <div className="flex gap-4 py-4">
             <button
               type="button"

--- a/src/components/DraftSwitch.tsx
+++ b/src/components/DraftSwitch.tsx
@@ -23,7 +23,7 @@ const DraftSwitch: FC<Props> = ({ draft, setDraft }) => {
           className={`absolute top-1 left-1 w-6 h-6 bg-white rounded-full transition-transform ${knob}`}
         />
       </div>
-      <span className="text-sm">{draft ? "Черновик" : "Опубликовано"}</span>
+      <span className="text-sm">{draft ? "Черновик (виден только автору)" : "Опубликовано (виден всем)"}</span>
     </label>
   );
 };

--- a/src/components/DraftSwitch.tsx
+++ b/src/components/DraftSwitch.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react";
+import { PencilIcon, DocumentCheckIcon } from "@heroicons/react/24/solid";
+
+interface Props {
+  draft: boolean;
+  setDraft: (v: boolean) => void;
+}
+
+const DraftSwitch: FC<Props> = ({ draft, setDraft }) => {
+  const knob = draft ? "" : "translate-x-8";
+  return (
+    <label className="flex items-center gap-2 cursor-pointer">
+      <input
+        type="checkbox"
+        className="sr-only"
+        checked={!draft}
+        onChange={() => setDraft(!draft)}
+      />
+      <div className="relative w-16 h-8 bg-gray-300 dark:bg-gray-600 rounded-full transition-colors">
+        <PencilIcon className="absolute left-1 top-1 w-6 h-6 text-gray-700 dark:text-gray-200" />
+        <DocumentCheckIcon className="absolute right-1 top-1 w-6 h-6 text-green-700" />
+        <div
+          className={`absolute top-1 left-1 w-6 h-6 bg-white rounded-full transition-transform ${knob}`}
+        />
+      </div>
+      <span className="text-sm">{draft ? "Черновик" : "Опубликовано"}</span>
+    </label>
+  );
+};
+
+export default DraftSwitch;

--- a/src/components/DraftSwitch.tsx
+++ b/src/components/DraftSwitch.tsx
@@ -17,8 +17,8 @@ const DraftSwitch: FC<Props> = ({ draft, setDraft }) => {
         onChange={() => setDraft(!draft)}
       />
       <div className="relative w-16 h-8 bg-gray-300 dark:bg-gray-600 rounded-full transition-colors">
-        <PencilIcon className="absolute left-1 top-1 w-6 h-6 text-gray-700 dark:text-gray-200" />
-        <DocumentCheckIcon className="absolute right-1 top-1 w-6 h-6 text-green-700" />
+        <PencilIcon className="absolute left-1 top-1 w-5 h-5 text-gray-700 dark:text-gray-200" />
+        <DocumentCheckIcon className="absolute right-1 top-1 w-5 h-5 text-green-700" />
         <div
           className={`absolute top-1 left-1 w-6 h-6 bg-white rounded-full transition-transform ${knob}`}
         />

--- a/src/components/EditEnemy.tsx
+++ b/src/components/EditEnemy.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { doc, updateDoc, deleteField } from "firebase/firestore";
 import { db } from "../firebase";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { PencilIcon, DocumentCheckIcon } from "@heroicons/react/24/solid";
+import DraftSwitch from "./DraftSwitch";
 import ImageDropZone from "./ImageDropZone";
 import EnemyFields from "./EnemyFields";
 import type { Enemy } from "../types";
@@ -62,25 +62,8 @@ const EditEnemy: React.FC<Props> = ({ enemy, onClose }) => {
         selectedTags={selectedTags}
         setSelectedTags={setSelectedTags}
       >
-        <div className="flex gap-4 py-2 items-center">
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input
-              type="radio"
-              name="draft"
-              checked={draft}
-              onChange={() => setDraft(true)}
-            />
-            <PencilIcon className="w-5 h-5" />Черновик
-          </label>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input
-              type="radio"
-              name="draft"
-              checked={!draft}
-              onChange={() => setDraft(false)}
-            />
-            <DocumentCheckIcon className="w-5 h-5" />Опубликовано
-          </label>
+        <div className="py-2">
+          <DraftSwitch draft={draft} setDraft={setDraft} />
         </div>
       </EnemyFields>
       <ImageDropZone imageURL={imageURL2} setImageURL={setImageURL2} ownerUid={enemy.authorUid} />

--- a/src/components/EnemyCard.tsx
+++ b/src/components/EnemyCard.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
-import { StarIcon as StarSolid } from "@heroicons/react/24/solid";
+import { StarIcon as StarSolid, PencilIcon } from "@heroicons/react/24/solid";
 import { StarIcon as StarOutline } from "@heroicons/react/24/outline";
 import { db } from "../firebase";
 import { useAuth } from "../contexts/AuthContext";
@@ -49,6 +49,9 @@ const EnemyCard: React.FC<Props> = ({ index, enemy, author, onClick }) => {
         className={`bg-white text-gray-900 dark:bg-gray-800 dark:text-white shadow-lg cursor-pointer  overflow-hidden relative w-full sm:w-40 sm:h-56 aspect-[2/3] hover:scale-110 flex flex-col rounded-xl transition-all duration-300 ease-in-out`}
         onClick={() => onClick(index)}
     >
+        {enemy.draft && (
+            <PencilIcon className="w-5 h-5 absolute top-2 left-2 text-gray-400" title="Черновик" />
+        )}
         {/* 1st image */}
         <img src={enemy.imageURL} alt={enemy.name} className="w-full h-1/2 sm:h-32 object-cover" />
 

--- a/src/components/EnemyFilters.tsx
+++ b/src/components/EnemyFilters.tsx
@@ -15,13 +15,15 @@ interface Props {
   setAuthor: (v: string) => void;
   sort: string;
   setSort: (v: string) => void;
+  draft: string;
+  setDraft: (v: string) => void;
   authors: Record<string, UserProfile>;
   onPrint: () => void;
   count: number;
   onRandom: () => void;
 }
 
-const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, setLiked, author, setAuthor, sort, setSort, authors, onPrint, count, onRandom }) => {
+const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, setLiked, author, setAuthor, sort, setSort, draft, setDraft, authors, onPrint, count, onRandom }) => {
   const fixedTags = useFixedTags();
   const [authorOpen, setAuthorOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -114,6 +116,15 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
           </div>
         )}
       </div>
+      <select
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        className="p-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white h-10 hover:bg-gray-100 dark:hover:bg-gray-500 transition cursor-pointer"
+      >
+        <option value="all">Все записи</option>
+        <option value="draft">Черновики</option>
+        <option value="published">Опубликованные</option>
+      </select>
       <button
         type="button"
         onClick={() => {
@@ -122,6 +133,7 @@ const EnemyFilters: React.FC<Props> = ({ search, setSearch, tag, setTag, liked, 
           setLiked(false);
           setAuthor('');
           setSort('name');
+          setDraft('all');
         }}
         className="flex items-center gap-1 p-2 rounded border text-blue-700 dark:text-sky-300 hover:text-blue-500 dark:hover:text-sky-200 border-blue-700 dark:border-sky-300 hover:border-blue-500 dark:hover:border-sky-200 transition h-10 cursor-pointer"
       >

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Enemy {
   authorUid: string;
   likedBy?: string[];
   createdAt?: string;
+  draft?: boolean;
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- allow marking enemies as draft
- add draft switch in AddEnemy and EditEnemy dialogs
- show pencil icon on draft cards
- filter by draft status in enemy list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433cb7f9148324925dc23cd50ec0d5