### PR TITLE
Add landing page and restructure navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,7 @@ const App: React.FC = () => {
       <Header />
       <main className="p-6 max-w-screen-xl mx-auto">
         <h2 className="text-3xl font-bold text-center">Каталог противников для игры Грань Вселенной</h2>
-        <p className="text-center text-gray-400 p-4">Официальный сайт игры: <a className="link" href="http://eotvrpg.ru/" target="_blank"><img src="./eotv-logo.png" alt="EOTV" className="w-5 h-5 inline-block" />eotvrpg.ru</a></p>
+        <p className="text-center text-gray-400 p-4">Официальный сайт игры: <a className="link" href="http://eotvrpg.ru/" target="_blank"><img src="/eotv-logo.png" alt="EOTV" className="w-5 h-5 inline-block" />eotvrpg.ru</a></p>
         <EnemyFilters
           search={search}
           setSearch={setSearch}

--- a/src/GeneratorsPage.tsx
+++ b/src/GeneratorsPage.tsx
@@ -1,0 +1,15 @@
+import Header from './components/Header';
+import Footer from './components/Footer';
+
+const GeneratorsPage: React.FC = () => (
+  <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-slate-900 dark:text-sky-200">
+    <Header />
+    <main className="p-6 max-w-screen-xl mx-auto">
+      <h2 className="text-2xl font-bold text-center mb-4">Генераторы для Грани Вселенной</h2>
+      <p className="text-center">В разработке</p>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default GeneratorsPage;

--- a/src/StartPage.tsx
+++ b/src/StartPage.tsx
@@ -1,0 +1,23 @@
+import Header from './components/Header';
+import Footer from './components/Footer';
+
+const StartPage: React.FC = () => (
+  <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-slate-900 dark:text-sky-200">
+    <Header />
+    <main className="p-6 max-w-screen-xl mx-auto flex flex-col sm:flex-row gap-6 justify-center items-center">
+      <a href="/eotv-enemies/" className="block w-full sm:w-80 h-56 rounded-lg overflow-hidden shadow-lg">
+        <img
+          src="https://private-user-images.githubusercontent.com/2280467/452084178-788e95a2-9a14-475c-beb1-7acaa5ac0ac9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDkyMzM0MDMsIm5iZiI6MTc0OTIzMzEwMywicGF0aCI6Ii8yMjgwNDY3LzQ1MjA4NDE3OC03ODhlOTVhMi05YTE0LTQ3NWMtYmViMS03YWNhYTVhYzBhYzkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDYwNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA2MDZUMTgwNTAzWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZTc3NzI0YzJmNzE0ZTI1MTcwODI2NzQ0MTJkYmQ1MTVkNjE1MDNjNzI1NmM5ZmIzNTMyMmY2MzdlZjliZWFiYiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.YVOUjIY-0qrGEh8BiwKegPwgwUuYLMe0gQY2cvQTrdg"
+          alt="Каталог противников"
+          className="object-cover w-full h-full"
+        />
+      </a>
+      <a href="/eotv-generators/" className="block w-full sm:w-80 h-56 rounded-lg overflow-hidden shadow-lg bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+        <span className="text-center px-4 font-bold">Генераторы для Грани Вселенной</span>
+      </a>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default StartPage;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,11 +4,11 @@ const Footer: React.FC = () => (
   <footer className="text-center text-gray-600 dark:text-gray-400 p-4 flex items-center justify-center gap-2">
     <span>Eugen Zha</span>
     <a href="https://t.me/d320stories" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 link">
-      <img src="./telegram.svg" alt="Telegram" className="w-5 h-5" />
+      <img src="/telegram.svg" alt="Telegram" className="w-5 h-5" />
       t.me/d320stories
     </a>
     <a href="https://github.com/nightskylark/d320" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 link">
-      <img src="./github.svg" alt="GItHub" className="w-5 h-5" />
+      <img src="/github.svg" alt="GItHub" className="w-5 h-5" />
       github.com/nightskylark/d320
     </a>
   </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ const Header: React.FC = () => {
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-2">
-            <img src="./logo.png" alt="d320" className="w-10 h-10" />
+            <img src="/logo.png" alt="d320" className="w-10 h-10" />
             <h1 className="text-2xl font-bold text-blue-700 dark:text-sky-300">d320</h1>
           </div>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,22 +2,32 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import StartPage from './StartPage';
+import GeneratorsPage from './GeneratorsPage';
 import { AuthProvider } from './contexts/AuthContext';
 import { TagProvider } from './contexts/TagContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+const pathname = window.location.pathname;
+let page: React.ReactElement;
+if (pathname.startsWith('/eotv-enemies')) {
+  page = (
+    <TagProvider>
+      <App />
+    </TagProvider>
+  );
+} else if (pathname.startsWith('/eotv-generators')) {
+  page = <GeneratorsPage />;
+} else {
+  page = <StartPage />;
+}
+
 root.render(
   <React.StrictMode>
-    <AuthProvider>
-      <TagProvider>
-        <App />
-      </TagProvider>
-    </AuthProvider>
+    <AuthProvider>{page}</AuthProvider>
   </React.StrictMode>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();


### PR DESCRIPTION
## Summary
- create a simple landing page with two cards
- add placeholder generators page
- switch index.tsx to render pages based on location
- use absolute asset paths so subpaths resolve correctly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843471ac65c8324a68a7c8c99222303