### PR TITLE
Update placeholders for enemy image drop zones

### DIFF
--- a/src/components/AddEnemy.tsx
+++ b/src/components/AddEnemy.tsx
@@ -154,7 +154,12 @@ const AddEnemy: React.FC = () => {
             </button>
           </div>
         </EnemyFields>
-        <ImageDropZone imageURL={imageURL2} setImageURL={setImageURL2} ownerUid={user?.uid || ""} />
+        <ImageDropZone
+          imageURL={imageURL2}
+          setImageURL={setImageURL2}
+          ownerUid={user?.uid || ""}
+          placeholder="/eotv-enemy-location-placeholder.png"
+        />
         </form>
       </div>
     </div>

--- a/src/components/EditEnemy.tsx
+++ b/src/components/EditEnemy.tsx
@@ -66,7 +66,12 @@ const EditEnemy: React.FC<Props> = ({ enemy, onClose }) => {
           <DraftSwitch draft={draft} setDraft={setDraft} />
         </div>
       </EnemyFields>
-      <ImageDropZone imageURL={imageURL2} setImageURL={setImageURL2} ownerUid={enemy.authorUid} />
+      <ImageDropZone
+        imageURL={imageURL2}
+        setImageURL={setImageURL2}
+        ownerUid={enemy.authorUid}
+        placeholder="/eotv-enemy-location-placeholder.png"
+      />
 
       <button
         onClick={onClose}

--- a/src/components/ImageDropZone.tsx
+++ b/src/components/ImageDropZone.tsx
@@ -7,9 +7,10 @@ interface Props {
   setImageURL: (url: string) => void;
   ownerUid: string;
   className?: string;
+  placeholder?: string;
 }
 
-const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, className }) => {
+const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, className, placeholder }) => {
   const [progress, setProgress] = useState(0);
 
   const handleFile = (file: File | null) => {
@@ -29,7 +30,7 @@ const ImageDropZone: React.FC<Props> = ({ imageURL, setImageURL, ownerUid, class
       onDragOver={(e) => e.preventDefault()}
     >
       <img
-        src={imageURL || "/eotv-enemy-placeholder.png"}
+        src={imageURL || placeholder || "/eotv-enemy-placeholder.png"}
         className="object-cover w-full h-full"
         alt=""
       />


### PR DESCRIPTION
## Summary
- allow specifying a placeholder image for `ImageDropZone`
- use a location placeholder image for the second drop zone when adding or editing an enemy

## Testing
- `npm run -s build` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*
- `npm run -s lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68435b469b408324bb68c9bc44d1d51a