### PR TITLE
Add profile about info and popup

### DIFF
--- a/src/components/AboutPopup.tsx
+++ b/src/components/AboutPopup.tsx
@@ -25,12 +25,14 @@ const AboutPopup: React.FC<Props> = ({ about, onClose }) => {
     };
   }, [onClose]);
 
+  if (!about) return null;
+
   return (
     <div
       ref={ref}
       className="absolute bottom-12 right-0 z-50 w-64 bg-white dark:bg-gray-800 text-gray-900 dark:text-white p-4 rounded shadow"
     >
-      <p className="whitespace-pre-wrap text-sm">{about || "Нет информации"}</p>
+      <p className="whitespace-pre-wrap text-sm">{about}</p>
     </div>
   );
 };

--- a/src/components/AboutPopup.tsx
+++ b/src/components/AboutPopup.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from "react";
+
+interface Props {
+  about: string;
+  onClose: () => void;
+}
+
+const AboutPopup: React.FC<Props> = ({ about, onClose }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleEsc);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleEsc);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-12 right-0 z-50 w-64 bg-white dark:bg-gray-800 text-gray-900 dark:text-white p-4 rounded shadow"
+    >
+      <p className="whitespace-pre-wrap text-sm">{about || "Нет информации"}</p>
+    </div>
+  );
+};
+
+export default AboutPopup;

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -22,6 +22,7 @@ const Auth: React.FC = () => {
       {
         displayName: user.displayName || "Unknown",
         photoURL: user.photoURL || "",
+        about: "",
       },
       { merge: true }
     );

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -146,14 +146,20 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     <div className="absolute bottom-4 right-4 flex items-center gap-2 relative">
                         <button
                             type="button"
-                            onClick={() => setAboutOpen(o => !o)}
+                            onClick={() => author?.about && setAboutOpen((o) => !o)}
                             className="flex items-center gap-2 focus:outline-none"
                         >
-                            <span className="text-sm underline">{author?.displayName || "Unknown"}</span>
-                            <img src={author?.photoURL} alt="Avatar" className="w-8 h-8 rounded-full border border-gray-500" />
+                            <span className="text-sm underline">
+                                {author?.displayName || "Unknown"}
+                            </span>
+                            <img
+                                src={author?.photoURL}
+                                alt="Avatar"
+                                className="w-8 h-8 rounded-full border border-gray-500"
+                            />
                         </button>
-                        {aboutOpen && (
-                            <AboutPopup about={author?.about || ""} onClose={() => setAboutOpen(false)} />
+                        {aboutOpen && author?.about && (
+                            <AboutPopup about={author.about} onClose={() => setAboutOpen(false)} />
                         )}
                     </div>
 

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -149,7 +149,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                             onClick={() => author?.about && setAboutOpen((o) => !o)}
                             className="flex items-center gap-2 focus:outline-none"
                         >
-                            <span className="text-sm underline">
+                            <span className="text-sm">
                                 {author?.displayName || "Unknown"}
                             </span>
                             <img

--- a/src/components/EnemyDetail.tsx
+++ b/src/components/EnemyDetail.tsx
@@ -8,6 +8,7 @@ import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 import { db } from "../firebase";
 import { printEnemies } from "../utils/printEnemies";
 import EditEnemy from "./EditEnemy";
+import AboutPopup from "./AboutPopup";
 import type { Enemy, UserProfile } from "../types";
 import LoginPrompt from "./LoginPrompt";
 
@@ -25,6 +26,7 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
     const [isEditing, setIsEditing] = useState(false);
     const [loginPrompt, setLoginPrompt] = useState(false);
     const [linkCopied, setLinkCopied] = useState(false);
+    const [aboutOpen, setAboutOpen] = useState(false);
     const liked = !!user && enemy.likedBy?.includes(user.uid);
 
     const toggleLike = async () => {
@@ -141,9 +143,18 @@ const EnemyDetail: React.FC<Props> = ({ enemy, author, onPrev, onNext, close, on
                     </div>
 
                     {/* Author */}
-                    <div className="absolute bottom-4 right-4 flex items-center gap-2">
-                        <span className="text-sm">{author?.displayName || "Unknown"}</span>
-                        <img src={author?.photoURL} alt="Avatar" className="w-8 h-8 rounded-full border border-gray-500" />
+                    <div className="absolute bottom-4 right-4 flex items-center gap-2 relative">
+                        <button
+                            type="button"
+                            onClick={() => setAboutOpen(o => !o)}
+                            className="flex items-center gap-2 focus:outline-none"
+                        >
+                            <span className="text-sm underline">{author?.displayName || "Unknown"}</span>
+                            <img src={author?.photoURL} alt="Avatar" className="w-8 h-8 rounded-full border border-gray-500" />
+                        </button>
+                        {aboutOpen && (
+                            <AboutPopup about={author?.about || ""} onClose={() => setAboutOpen(false)} />
+                        )}
                     </div>
 
                     {/* Action buttons */}

--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -51,10 +51,13 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     await updateProfile(user, { displayName, photoURL });
     await user.reload();
     const refreshed = auth.currentUser;
-    // clone with prototype so context updates without losing methods
-    const clone =
-      refreshed && Object.assign(Object.create(Object.getPrototypeOf(refreshed)), refreshed);
-    setAuthUser(clone || null);
+    // clone user with property descriptors so methods like getIdToken stay intact
+    let clone: typeof refreshed | null = null;
+    if (refreshed) {
+      clone = Object.create(Object.getPrototypeOf(refreshed));
+      Object.defineProperties(clone, Object.getOwnPropertyDescriptors(refreshed));
+    }
+    setAuthUser(clone);
     await setDoc(
       doc(db, "users", user.uid),
       { displayName, photoURL, about: about.trim() },

--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { doc, setDoc, getDoc } from "firebase/firestore";
-import { updateProfile, User } from "firebase/auth";
+import { updateProfile } from "firebase/auth";
 import { db, auth } from "../firebase";
 import { useAuth, useSetAuthUser } from "../contexts/AuthContext";
 import AvatarDropZone from "./AvatarDropZone";
@@ -51,8 +51,10 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     await updateProfile(user, { displayName, photoURL });
     await user.reload();
     const refreshed = auth.currentUser;
-    // set a new object reference so context updates
-    setAuthUser(refreshed ? ({ ...refreshed } as User) : null);
+    // clone with prototype so context updates without losing methods
+    const clone =
+      refreshed && Object.assign(Object.create(Object.getPrototypeOf(refreshed)), refreshed);
+    setAuthUser(clone || null);
     await setDoc(
       doc(db, "users", user.uid),
       { displayName, photoURL, about: about.trim() },

--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -55,7 +55,7 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     setAuthUser(refreshed ? ({ ...refreshed } as User) : null);
     await setDoc(
       doc(db, "users", user.uid),
-      { displayName, photoURL, about },
+      { displayName, photoURL, about: about.trim() },
       { merge: true }
     );
     onClose();

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,5 @@ export interface Enemy {
 export interface UserProfile {
   displayName: string;
   photoURL: string;
+  about?: string;
 }


### PR DESCRIPTION
## Summary
- support `about` text in `UserProfile`
- include About field in ProfileDialog and store in Firestore
- show about popup from author in EnemyDetail
- create AboutPopup component to display the author bio
- store empty about field on login

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684366ca0da48324ac053802b8abe1d1