### PR TITLE
Add "About" field to profile settings

### DIFF
--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { doc, setDoc } from "firebase/firestore";
+import { doc, setDoc, getDoc } from "firebase/firestore";
 import { updateProfile, User } from "firebase/auth";
 import { db, auth } from "../firebase";
 import { useAuth, useSetAuthUser } from "../contexts/AuthContext";
@@ -15,6 +15,7 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
   const setAuthUser = useSetAuthUser();
   const [displayName, setDisplayName] = useState(user?.displayName || "");
   const [photoURL, setPhotoURL] = useState(user?.photoURL || "");
+  const [about, setAbout] = useState("");
   const formRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -34,6 +35,18 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     };
   }, [onClose]);
 
+  useEffect(() => {
+    const fetchAbout = async () => {
+      if (!user) return;
+      const snap = await getDoc(doc(db, "users", user.uid));
+      if (snap.exists()) {
+        const data = snap.data() as { about?: string };
+        setAbout(data.about || "");
+      }
+    };
+    fetchAbout();
+  }, [user]);
+
   const saveProfile = async () => {
     if (!user) return;
     await updateProfile(user, { displayName, photoURL });
@@ -41,7 +54,7 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     const refreshed = auth.currentUser;
     // set a new object reference so context updates
     setAuthUser(refreshed ? ({ ...refreshed } as User) : null);
-    await setDoc(doc(db, "users", user.uid), { displayName, photoURL }, { merge: true });
+    await setDoc(doc(db, "users", user.uid), { displayName, photoURL, about }, { merge: true });
     onClose();
   };
 
@@ -71,6 +84,12 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
           type="text"
           value={displayName}
           onChange={(e) => setDisplayName(e.target.value)}
+          className="w-full p-2 mt-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
+        />
+        <textarea
+          value={about}
+          onChange={(e) => setAbout(e.target.value)}
+          placeholder="О себе"
           className="w-full p-2 mt-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-neonBlue"
         />
         <div className="flex gap-4 mt-6 w-full">

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -21,3 +21,4 @@ export const provider = new GoogleAuthProvider();
 
 export const enemiesCollection = collection(db, "eotv-enemies");
 export const tagsCollection = collection(db, "eotv-enemy-tags");
+export const usersCollection = collection(db, "users");

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,5 @@ export interface Enemy {
 export interface UserProfile {
   displayName: string;
   photoURL: string;
+  about?: string;
 }


### PR DESCRIPTION
## Summary
- add `usersCollection` constant
- extend `UserProfile` type with optional `about` field
- load and edit `about` in `ProfileDialog`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843e102452c8324aef02eb12816bc35