### PR TITLE
Fix profile save reload bug

### DIFF
--- a/src/components/ProfileDialog.tsx
+++ b/src/components/ProfileDialog.tsx
@@ -52,8 +52,10 @@ const ProfileDialog: React.FC<Props> = ({ onClose }) => {
     await updateProfile(user, { displayName, photoURL });
     await user.reload();
     const refreshed = auth.currentUser;
-    // set a new object reference so context updates
-    setAuthUser(refreshed ? ({ ...refreshed } as User) : null);
+    // preserve Firebase User prototype when creating a new reference
+    const clone =
+      refreshed && Object.assign(Object.create(Object.getPrototypeOf(refreshed)), refreshed);
+    setAuthUser(clone as User | null);
     await setDoc(doc(db, "users", user.uid), { displayName, photoURL, about }, { merge: true });
     onClose();
   };


### PR DESCRIPTION
## Summary
- preserve firebase User prototype when updating profile

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6843e4f0fca88324b3dba1a5e4fe26b9