### PR TITLE
Fix Markdown rendering

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -18,8 +18,10 @@ const md = new MarkdownIt('commonmark', {
     'hr',
   ]);
 
-md.renderer.rules.paragraph_open = () => '<p class="text-sm mt-2">';
-md.renderer.rules.paragraph_close = () => '</p>';
+md.renderer.rules.paragraph_open = (tokens, idx) =>
+  tokens[idx].hidden ? '' : '<p class="text-sm mt-2">';
+md.renderer.rules.paragraph_close = (tokens, idx) =>
+  tokens[idx].hidden ? '' : '</p>';
 md.renderer.rules.strong_open = () => '<strong class="font-bold">';
 md.renderer.rules.strong_close = () => '</strong>';
 md.renderer.rules.em_open = () => '<em class="italic">';
@@ -47,4 +49,10 @@ md.renderer.rules.heading_open = (tokens: unknown, idx: number) => {
 md.renderer.rules.heading_close = (tokens: unknown, idx: number) =>
   `</${(tokens as Record<number, { tag: string }>)[idx].tag}>`;
 
-export const renderMarkdown = (text: string): string => md.render(text);
+export const renderMarkdown = (text: string): string => {
+  const cleaned = text
+    .replace(/<br\s*\/?>/gi, '  \n')
+    .replace(/<\/p>\s*<p>/gi, '\n\n')
+    .replace(/<\/?p>/gi, '\n');
+  return md.render(cleaned);
+};


### PR DESCRIPTION
## Summary
- preserve tight list layout when rendering markdown
- convert `<br>` and `<p>` fragments from the editor back to plain markdown before rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a990ce28832488345ad02dc14e11