### PR TITLE
Add manual deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Manual deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy environment'
+        required: true
+        default: prod
+      version:
+        description: 'Application version'
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CMD="npm run deploy -- --env ${{ inputs.environment }}"
+          if [ -n "${{ inputs.version }}" ]; then
+            CMD="$CMD --version ${{ inputs.version }}"
+          fi
+          echo "Running $CMD"
+          $CMD
+


### PR DESCRIPTION
## Summary
- add manual deploy workflow triggered by `workflow_dispatch`
- runs `npm run deploy` with environment and optional version flags

## Testing
- `npm test`

To deploy manually, go to the **Actions** tab, select **Manual deploy**, and click **Run workflow**, providing the desired inputs.

------
https://chatgpt.com/codex/tasks/task_e_6895d06e2c2c83249b24308352fcc332