### PR TITLE
fix: configure git user for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
- configure git user/email before running gh-pages deploy

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d68e96fc8324a8dec7a409958cf6