### PR TITLE
fix: configure base path via env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
 
       - name: Build
+        env:
+          VITE_BASE: /d320/
         run: npm run build
 
       - name: Configure git auth for gh-pages

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,9 +2,12 @@ import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 
-const isCI = !!process.env.GITHUB_REPOSITORY;
-// for pages by address https://<user>.github.io/d320/
-const base = isCI ? '/d320/' : '/';
+// Allow overriding the base path via environment variable.
+// This is useful for deploying to GitHub Pages where the app is served
+// from a subdirectory like https://<user>.github.io/d320/.
+// For all other environments (including https://d320.world) we keep the
+// root path so assets are resolved correctly.
+const base = process.env.VITE_BASE || '/';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
## Summary
- allow overriding Vite base path via `VITE_BASE` env
- set `VITE_BASE=/d320/` when building in deploy workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e20ac81c83249a2bfc09a4d0d500